### PR TITLE
Fix urlencode compatibility with Python2/3.

### DIFF
--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 import json
-import urllib
+from six.moves.urllib.parse import urlparse, urlencode
 
 import requests
 
@@ -105,7 +105,7 @@ class Request(object):
                 'authorization': 'Token {}'.format(self.token),
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-            data=urllib.urlencode({
+            data=urlencode({
                 'private_key': self.private_key.strip('\n')
             })
         )


### PR DESCRIPTION
I get an issue with Version 3.0.0 and urlencode under python3:

```
Traceback (most recent call last):
  File "./create-dhcp-from-netbox.py", line 8, in <module>
    token='...'
  File "/usr/lib/python3.6/site-packages/pynetbox-3.0.0-py3.6.egg/pynetbox/api.py", line 111, in __init__
    self.api_kwargs.update(session_key=req.get_session_key())
  File "/usr/lib/python3.6/site-packages/pynetbox-3.0.0-py3.6.egg/pynetbox/lib/query.py", line 108, in get_session_key
    data=urllib.urlencode({
AttributeError: module 'urllib' has no attribute 'urlencode'

```
This should fix it. Tested with python2 & 3.
