### PR TITLE
Patch and ssl. Addresses #21 and part of #22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib64/
+lib/
 parts/
 sdist/
 var/

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -80,7 +80,7 @@ class Api(object):
     """
 
     def __init__(self, url, token=None, private_key=None,
-                 private_key_file=None, version=None):
+                 private_key_file=None, version=None, ssl_verify=True):
         if private_key and private_key_file:
             raise ValueError(
                 '"private_key" and "private_key_file" cannot be used together.'
@@ -92,6 +92,7 @@ class Api(object):
             "private_key": private_key,
             "private_key_file": private_key_file,
             "base_url": base_url,
+            "ssl_verify": ssl_verify,
         }
 
         if self.api_kwargs.get('private_key_file'):
@@ -99,13 +100,14 @@ class Api(object):
                 private_key = kf.read()
                 self.api_kwargs.update(private_key=private_key)
         if not version:
-            version = Request(base=base_url).get_version()
+            version = Request(base=base_url, ssl_verify=ssl_verify).get_version()
         self.api_kwargs.update(version=version)
 
         req = Request(
             base=base_url,
             token=token,
-            private_key=private_key
+            private_key=private_key,
+            ssl_verify=ssl_verify
         )
         if token and private_key:
             self.api_kwargs.update(session_key=req.get_session_key())

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -100,7 +100,8 @@ class Api(object):
                 private_key = kf.read()
                 self.api_kwargs.update(private_key=private_key)
         if not version:
-            version = Request(base=base_url, ssl_verify=ssl_verify).get_version()
+            version = Request(base=base_url,
+                              ssl_verify=ssl_verify).get_version()
         self.api_kwargs.update(version=version)
 
         req = Request(

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -241,6 +241,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             version=self.version,
+            ssl_verify=self.ssl_verify
         ).patch(upd)
 
 

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -189,7 +189,8 @@ class Endpoint(object):
 
         :returns: A single updated object.
 
-        :raises ValueError: If ID is not passed as a poitional arg, a value in a dict or as a kwarg
+        :raises ValueError: If ID is not passed as a poitional arg, a value
+            in a dict or as a kwarg
 
         :Examples:
 
@@ -243,7 +244,6 @@ class Endpoint(object):
             version=self.version,
             ssl_verify=self.ssl_verify
         ).patch(upd)
-
 
     def filter(self, *args, **kwargs):
         """Queries the 'ListView' of a given endpoint.

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -212,22 +212,28 @@ class Endpoint(object):
         mydevice
         >>>
         """
-        if len(args) > 0:
+        key = None
+        upd = None
+        if len(args) == 1:
             if isinstance(args[0], dict):
                 if 'id' in args[0]:
                     key = args[0].pop('id')
-                else:
-                    key = None
-            else:
-                try:
-                    key = int(args[0])
-                except ValueError:
-                    key = None
+                    upd = args[0]
+        elif len(args) > 1:
+            try:
+                key = int(args[0])
+                upd = args[1]
+            except ValueError:
+                key = None
         elif 'id' in kwargs:
             key = kwargs.pop('id')
+            upd = kwargs
 
         if not key:
             raise ValueError('No ID in provided args')
+
+        if not upd:
+            raise ValueError("No update data")
 
         return Request(
             key=key,
@@ -235,7 +241,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             version=self.version,
-        ).patch(args[1] if len(args) > 0 else kwargs)
+        ).patch(upd)
 
 
     def filter(self, *args, **kwargs):

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -56,6 +56,7 @@ class Endpoint(object):
         self.token = api_kwargs.get('token')
         self.version = api_kwargs.get('version')
         self.session_key = api_kwargs.get('session_key')
+        self.ssl_verify = api_kwargs.get('ssl_verify')
         self.url = '{base_url}/{app}/{endpoint}'.format(
             base_url=self.base_url,
             app=app_name,
@@ -109,6 +110,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             version=self.version,
+            ssl_verify=self.ssl_verify,
         )
         ret_kwargs = dict(
             api_kwargs=self.api_kwargs,
@@ -165,7 +167,8 @@ class Endpoint(object):
             base=self.url,
             token=self.token,
             session_key=self.session_key,
-            version=self.version
+            version=self.version,
+            ssl_verify=self.ssl_verify,
         )
         ret_kwargs = dict(
             api_kwargs=self.api_kwargs,
@@ -294,6 +297,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             version=self.version,
+            ssl_verify=self.ssl_verify,
         )
         ret_kwargs = dict(
             api_kwargs=self.api_kwargs,
@@ -362,6 +366,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             version=self.version,
+            ssl_verify=self.ssl_verify,
         ).post(args[0] if len(args) > 0 else kwargs)
 
 
@@ -376,6 +381,7 @@ class DetailEndpoint(object):
         self.token = parent_obj.api_kwargs.get('token')
         self.version = parent_obj.api_kwargs.get('version')
         self.session_key = parent_obj.api_kwargs.get('session_key')
+        self.ssl_verify = parent_obj.api_kwargs.get('ssl_verify')
         self.url = "{}/{}/{}/".format(
             parent_obj.endpoint_meta.get('url'),
             parent_obj.id,
@@ -386,6 +392,7 @@ class DetailEndpoint(object):
             token=self.token,
             session_key=self.session_key,
             version=self.version,
+            ssl_verify=self.ssl_verify,
         )
 
     def list(self):

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -174,6 +174,67 @@ class Endpoint(object):
 
         return self.return_obj(req.get(), **ret_kwargs)
 
+    def update(self, *args, **kwargs):
+        """Updates an object on an endpoint.
+
+        :arg int,optional key: id for the item to be
+            updated. Can
+
+        :arg str,optional \**kwargs: Accepts the same keyword args as
+            filter(). Any search argeter the endpoint accepts can
+            be added as a keyword arg.
+
+        :returns: A single updated object.
+
+        :raises ValueError: If ID is not passed as a poitional arg, a value in a dict or as a kwarg
+
+        :Examples:
+
+        Update a device, given a device with ID of "10"
+
+        If using positional args, ID must be first
+
+        >>> nb.dcim.devices.update(10, {'name': 'mydevice'})
+        mydevice
+        >>>
+
+        Using kwargs
+
+        >>> nb.devices.update(id=10, name='mydevice')
+        mydevice
+        >>>
+
+        Using a dict
+        >>> nb.devices.update({'id': 10, 'name': 'mydevice'})
+        mydevice
+        >>>
+        """
+        if len(args) > 0:
+            if isinstance(args[0], dict):
+                if 'id' in args[0]:
+                    key = args.pop('id')
+                else:
+                    key = None
+            else:
+                try:
+                    key = int(args[0])
+                except ValueError:
+                    key = None
+        elif 'id' in kwargs:
+            key = kwargs.pop('id')
+
+        if not key:
+            raise ValueError('No ID in provided args')
+
+        return Request(
+            key=key,
+            base=self.url,
+            token=self.token,
+            session_key=self.session_key,
+            version=self.version,
+        ).patch(args[1] if len(args) > 0 else kwargs)
+
+
     def filter(self, *args, **kwargs):
         """Queries the 'ListView' of a given endpoint.
 

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -215,7 +215,7 @@ class Endpoint(object):
         if len(args) > 0:
             if isinstance(args[0], dict):
                 if 'id' in args[0]:
-                    key = args.pop('id')
+                    key = args[0].pop('id')
                 else:
                     key = None
             else:

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -267,7 +267,7 @@ class Request(object):
             headers.update(
                 {'X-Session-Key': self.session_key}
             )
-        req = requests.patch(self.url, headers=headers, data=json.dumps(data))
+        req = requests.patch(self.url, headers=headers, data=json.dumps(data), verify=self.ssl_verify)
         if req.ok:
             return json.loads(req.text)
         else:

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -239,7 +239,10 @@ class Request(object):
             headers.update(
                 {'X-Session-Key': self.session_key}
             )
-        req = requests.put(self.url, headers=headers, data=json.dumps(data), verify=self.ssl_verify)
+        req = requests.put(self.url,
+                           headers=headers,
+                           data=json.dumps(data),
+                           verify=self.ssl_verify)
         if req.ok:
             return json.loads(req.text)
         else:
@@ -267,7 +270,10 @@ class Request(object):
             headers.update(
                 {'X-Session-Key': self.session_key}
             )
-        req = requests.patch(self.url, headers=headers, data=json.dumps(data), verify=self.ssl_verify)
+        req = requests.patch(self.url,
+                             headers=headers,
+                             data=json.dumps(data),
+                             verify=self.ssl_verify)
         if req.ok:
             return json.loads(req.text)
         else:

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -55,7 +55,8 @@ class Request(object):
     """
 
     def __init__(self, base=None, filters=None, key=None, token=None,
-                 private_key=None, version=None, session_key=None):
+                 private_key=None, version=None, session_key=None,
+                 ssl_verify=True):
         """
         Instantiates a new Request object
 
@@ -76,6 +77,7 @@ class Request(object):
         self.private_key = private_key
         self.version = version
         self.session_key = session_key
+        self.ssl_verify = ssl_verify
 
     def get_version(self):
         """Query the netbox API for its API-Version.
@@ -85,7 +87,8 @@ class Request(object):
         :returns: String containing version.
         """
         ret = requests.get(
-            "{}/".format(self.base)
+            "{}/".format(self.base),
+            verify=self.ssl_verify
         ).headers.get('API-Version', '1.0')
         setattr(self, 'version', ret)
         return ret
@@ -107,7 +110,8 @@ class Request(object):
             },
             data=urlencode({
                 'private_key': self.private_key.strip('\n')
-            })
+            }),
+            verify=self.ssl_verify
         )
         if req.ok:
             return json.loads(req.text)['session_key']
@@ -187,7 +191,7 @@ class Request(object):
 
         def make_request(url):
 
-            req = requests.get(url, headers=headers)
+            req = requests.get(url, headers=headers, verify=self.ssl_verify)
             if req.ok:
                 return json.loads(req.text)
             else:
@@ -235,7 +239,7 @@ class Request(object):
             headers.update(
                 {'X-Session-Key': self.session_key}
             )
-        req = requests.put(self.url, headers=headers, data=json.dumps(data))
+        req = requests.put(self.url, headers=headers, data=json.dumps(data), verify=self.ssl_verify)
         if req.ok:
             return json.loads(req.text)
         else:
@@ -293,7 +297,8 @@ class Request(object):
         req = requests.post(
             self.normalize_url(self.url),
             headers=headers,
-            data=json.dumps(data)
+            data=json.dumps(data),
+            verify=self.ssl_verify
         )
         if req.ok:
             return json.loads(req.text)
@@ -321,6 +326,7 @@ class Request(object):
         req = requests.delete(
             "{}".format(self.url),
             headers=headers,
+            verify=self.ssl_verify
         )
         if req.ok:
             return True

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -241,6 +241,34 @@ class Request(object):
         else:
             raise RequestError(req)
 
+    def patch(self, data):
+        """Makes PATCH request. Nearly identical to PUT.
+
+        Makes a PATCH request to NetBox's API. Adds the session key to
+        headers if the `private_key` attribute was populated.
+
+        :param data: (dict) Contains a dict that will be turned into a
+            json object and sent to the API.
+        :raises: RequestError if req.ok returns false.
+        :returns: Dict containing the response from NetBox's API.
+        """
+        # TODO: DRY
+        headers = {
+            'Content-Type': 'application/json; version={};'.format(
+                self.version or self.get_version()
+            ),
+            'authorization': 'Token {}'.format(self.token),
+        }
+        if self.session_key:
+            headers.update(
+                {'X-Session-Key': self.session_key}
+            )
+        req = requests.patch(self.url, headers=headers, data=json.dumps(data))
+        if req.ok:
+            return json.loads(req.text)
+        else:
+            raise RequestError(req)
+
     def post(self, data):
         """Makes POST request.
 

--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -171,7 +171,8 @@ class Record(object):
         if self.url:
             req = Request(
                 base=self.url,
-                version=self.api_kwargs.get('version')
+                version=self.api_kwargs.get('version'),
+                ssl_verify=self.api_kwargs.get('ssl_verify')
             )
             self._parse_values(req.get())
             self.has_details = True
@@ -228,7 +229,8 @@ class Record(object):
                     base=self.endpoint_meta.get('url'),
                     token=self.api_kwargs.get('token'),
                     session_key=self.api_kwargs.get('session_key'),
-                    version=self.api_kwargs.get('version')
+                    version=self.api_kwargs.get('version'),
+                    ssl_verify=self.api_kwargs.get('ssl_verify')
                 )
                 if req.put(self.serialize()):
                     return True
@@ -251,7 +253,8 @@ class Record(object):
             base=self.endpoint_meta.get('url'),
             token=self.api_kwargs.get('token'),
             session_key=self.api_kwargs.get('session_key'),
-            version=self.api_kwargs.get('version')
+            version=self.api_kwargs.get('version'),
+            ssl_verify=self.api_kwargs.get('ssl_verify')
         )
         if req.delete():
             return True

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -43,7 +43,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_filter(self):
@@ -63,7 +64,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_get(self):
@@ -82,7 +84,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
 

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -212,13 +212,13 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
             'id': 1,
             'name': 'test-device'
         }
-        ret_id_arg = nb.devices.update(1, **data)
+        ret_id_arg = nb.devices.update(1, data)
         self.assertTrue(ret_id_arg)
 
         ret_id_kwarg = nb.devices.update(id=1, name='test-device')
         self.assertTrue(ret_id_kwarg)
 
-        ret_id_in_dict = nb.devices.update(**data_with_id)
+        ret_id_in_dict = nb.devices.update(data_with_id)
         self.assertTrue(ret_id_in_dict)
 
     @patch(

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -49,7 +49,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_filter(self):
@@ -69,7 +70,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_get(self):
@@ -90,7 +92,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_delete(self):
@@ -108,14 +111,16 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
             delete.assert_called_with(
                 'http://localhost:8000/api/{}/{}/1/'.format(
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=AUTH_HEADERS
+                headers=AUTH_HEADERS,
+                verify=True
             )
 
     def test_compare(self):
@@ -161,7 +166,8 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
                 self.app,
                 self.name.replace('_', '-')
             ),
-            headers=HEADERS
+            headers=HEADERS,
+            verify=True
         )
 
     @patch(
@@ -178,7 +184,8 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
                 self.app,
                 self.name.replace('_', '-')
             ),
-            headers=HEADERS
+            headers=HEADERS,
+            verify=True
         )
 
     @patch(
@@ -192,6 +199,27 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(ret_serialized)
         self.assertFalse(ret._compare())
         self.assertEqual(ret_serialized['serial'], '123123123123')
+
+    @patch(
+        'pynetbox.lib.query.requests.patch',
+        return_value=Response(fixture='dcim/device.json')
+    )
+    def test_update(self, mock):
+        data = {
+            'name': 'test-device'
+        }
+        data_with_id = {
+            'id': 1,
+            'name': 'test-device'
+        }
+        ret_id_arg = nb.devices.update(1, **data)
+        self.assertTrue(ret_id_arg)
+
+        ret_id_kwarg = nb.devices.update(id=1, name='test-device')
+        self.assertTrue(ret_id_kwarg)
+
+        ret_id_in_dict = nb.devices.update(**data_with_id)
+        self.assertTrue(ret_id_in_dict)
 
     @patch(
         'pynetbox.lib.query.requests.post',
@@ -329,7 +357,8 @@ class InterfaceTestCase(unittest.TestCase, GenericTest):
         self.assertEqual(len(ret), 71)
         mock.assert_called_with(
             'http://localhost:8000/api/dcim/interfaces/?limit=221&offset=50'.format(self.name),
-            headers=HEADERS
+            headers=HEADERS,
+            verify=True
         )
 
 

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -54,7 +54,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_filter(self):
@@ -74,7 +75,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_get(self):
@@ -95,7 +97,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
             if self.ip_obj_fields:
                 for field in self.ip_obj_fields:
@@ -135,7 +138,8 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         ret = pfx.available_ips.list()
         mock.assert_called_with(
             'http://localhost:8000/api/ipam/prefixes/1/available-ips/'.format(self.name),
-            headers=HEADERS
+            headers=HEADERS,
+            verify=True
         )
         self.assertTrue(ret)
         self.assertEqual(len(ret), 3)
@@ -170,6 +174,7 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
             'http://localhost:8000/api/ipam/prefixes/1/available-ips/'.format(self.name),
             headers=POST_HEADERS,
             data=json.dumps(create_parms),
+            verify=True
         )
         self.assertTrue(ret)
         self.assertEqual(ret, expected_result)
@@ -186,7 +191,8 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         ret = pfx.available_prefixes.list()
         mock.assert_called_with(
             'http://localhost:8000/api/ipam/prefixes/1/available-prefixes/'.format(self.name),
-            headers=HEADERS
+            headers=HEADERS,
+            verify=True
         )
         self.assertTrue(ret)
 
@@ -208,6 +214,7 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
             'http://localhost:8000/api/ipam/prefixes/1/available-prefixes/'.format(self.name),
             headers=POST_HEADERS,
             data=json.dumps(create_parms),
+            verify=True
         )
         self.assertTrue(ret)
 

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -44,7 +44,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_filter(self):
@@ -64,7 +65,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_get(self):
@@ -83,7 +85,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
 

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -44,7 +44,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_filter(self):
@@ -64,7 +65,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
     def test_get(self):
@@ -83,7 +85,8 @@ class GenericTest(object):
                     self.app,
                     self.name.replace('_', '-')
                 ),
-                headers=HEADERS
+                headers=HEADERS,
+                verify=True
             )
 
 


### PR DESCRIPTION
This was originally going to be two separate PRs, but the update feature also required the ssl change so we ended up mashing them together.

### SSL for #21 
This part is pretty simple.  It just adds an additional argument to several methods and the constructors of classes that end up making HTTP calls, to support Requests' 'verify' argument, implemented here as 'ssl_verify' to be more explicit about what the option does.  It defaults to 'True', which is the current default behavior, or will accept 'False' or a string that is a path to a CA cert (see requests docs).  Usage is simple:

```
netbox = pynetbox.api(
    myurl,
    token=mytoken,
    ssl_verify=False
)
```

Reference is here: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification

### PATCH for part 1 of #22 
This portion of the PR adds a patch() method to Request.  It's a near copy of put(), merely using the different HTTP method.

It also adds an update() method to Endpoint, which implements the first suggestion in #22, a way to update a resource given a dict, without retrieving it as an object first.  

I did _not_ implement an update() method in the Record class.  Though it's very doable, there were some design considerations that probably need to be made - i.e. how to handle nested Records, etc.  It won't be hard, but I figured it would warrant a conversation first.

Let me know if this looks useful, and if you'd want any changes to what's here.

Cheers!
