### PR TITLE
Fix endpoint trailing / which causes a lot of redirects

### DIFF
--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -56,7 +56,7 @@ class Endpoint(object):
         self.token = api_kwargs.get('token')
         self.version = api_kwargs.get('version')
         self.session_key = api_kwargs.get('session_key')
-        self.url = '{base_url}/{app}/{endpoint}'.format(
+        self.url = '{base_url}/{app}/{endpoint}/'.format(
             base_url=self.base_url,
             app=app_name,
             endpoint=name.replace('_', '-'),
@@ -105,7 +105,7 @@ class Endpoint(object):
         >>>
         """
         req = Request(
-            base='{}/'.format(self.url),
+            base=self.url,
             token=self.token,
             session_key=self.session_key,
             version=self.version,


### PR DESCRIPTION
I noticed the following pattern in my nginx logs:

```
[11/Jan/2018:02:01:26 -0800] "GET /api/ HTTP/1.1" 200 353 "-" "python-requests/2.10.0"
[11/Jan/2018:02:01:27 -0800] "GET /api/tenancy/tenants HTTP/1.1" 301 0 "-" "python-requests/2.10.0"
[11/Jan/2018:02:01:28 -0800] "GET /api/tenancy/tenants/ HTTP/1.1" 200 390 "-" "python-requests/2.10.0"
[11/Jan/2018:02:10:08 -0800] "GET /api/ HTTP/1.1" 200 353 "-" "python-requests/2.10.0"
[11/Jan/2018:02:10:09 -0800] "GET /api/tenancy/tenants HTTP/1.1" 301 0 "-" "python-requests/2.10.0"
[11/Jan/2018:02:10:09 -0800] "GET /api/tenancy/tenants/ HTTP/1.1" 200 390 "-" "python-requests/2.10.0"
[11/Jan/2018:02:10:34 -0800] "GET /api/ HTTP/1.1" 200 353 "-" "python-requests/2.10.0"
[11/Jan/2018:02:10:35 -0800] "GET /api/tenancy/tenants HTTP/1.1" 301 0 "-" "python-requests/2.10.0"
[11/Jan/2018:02:10:35 -0800] "GET /api/tenancy/tenants/ HTTP/1.1" 200 390 "-" "python-requests/2.10.0"
```

I turned on debugging for Requests and found the cause:

```
send: 'GET /api/ HTTP/1.1\r\nHost: netbox.example.com\r\nConnection: keep-alive\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nUser-Agent: python-requests/2.10.0\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Server: nginx/1.10.3 (Ubuntu)
header: Date: Thu, 11 Jan 2018 10:10:34 GMT
header: Content-Type: application/json
header: Content-Length: 353
header: Connection: keep-alive
header: API-Version: 2.2
header: Allow: GET, HEAD, OPTIONS
header: X-Frame-Options: SAMEORIGIN
header: Vary: Accept, Cookie
header: P3P: CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"
header: X-Cache-Status: MISS
send: 'GET /api/tenancy/tenants HTTP/1.1\r\nHost: netbox.example.com\r\nConnection: keep-alive\r\nAccept-Encoding: gzip, deflate\r\naccept: application/json; version=2.2;\r\nUser-Agent: python-requests/2.10.0\r\nauthorization: Token 1234567890\r\n\r\n'
reply: 'HTTP/1.1 301 Moved Permanently\r\n'
header: Server: nginx/1.10.3 (Ubuntu)
header: Date: Thu, 11 Jan 2018 10:10:35 GMT
header: Content-Type: text/html; charset=utf-8
header: Content-Length: 0
header: Connection: keep-alive
header: Location: /api/tenancy/tenants/
header: P3P: CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"
header: X-Cache-Status: MISS
send: 'GET /api/tenancy/tenants/ HTTP/1.1\r\nHost: netbox.example.com\r\nConnection: keep-alive\r\nAccept-Encoding: gzip, deflate\r\naccept: application/json; version=2.2;\r\nUser-Agent: python-requests/2.10.0\r\nauthorization: Token 1234567890\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
header: Server: nginx/1.10.3 (Ubuntu)
header: Date: Thu, 11 Jan 2018 10:10:35 GMT
header: Content-Type: application/json
header: Content-Length: 390
header: Connection: keep-alive
header: API-Version: 2.2
header: Allow: GET, POST, HEAD, OPTIONS
header: X-Frame-Options: SAMEORIGIN
header: Vary: Accept, Cookie
header: P3P: CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"
header: X-Cache-Status: MISS
```

I was getting a 301 on each get request:
```
reply: 'HTTP/1.1 301 Moved Permanently\r\n'
header: Location: /api/tenancy/tenants/
```