### PR TITLE
Fixes #36 - fixes AttributeError if attr was None.

### DIFF
--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -76,7 +76,7 @@ class Record(object):
             if self.has_details is False and k != 'keys':
                 if self.full_details():
                     ret = getattr(self, k, None)
-                    if ret:
+                    if ret or hasattr(self, k):
                         return ret
 
         raise AttributeError('object has no attribute "{}"'.format(k))


### PR DESCRIPTION
`__getattr__` on Record objects would raise an AttributeError if the attribute existed but was none.