### PR TITLE
fix some urlencoding problems

### DIFF
--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -25,10 +25,7 @@ def url_param_builder(param_dict):
     Creates URL paramters (e.g. '.../?xyz=r21&abc=123') from a dict
     passed in param_dict
     '''
-    param_list = []
-    for key, val in param_dict.items():
-        param_list.append('{}={}'.format(key, val))
-    return '?{}'.format('&'.join(param_list))
+    return '?{}'.format(urlencode(param_dict))
 
 
 class RequestError(Exception):
@@ -150,9 +147,9 @@ class Request(object):
             for k, v in input.items():
                 if isinstance(v, list):
                     for i in v:
-                        yield "{}={}".format(k, i)
+                        yield urlencode({k: i})
                 else:
-                    yield "{}={}".format(k, v)
+                    yield urlencode({k: v})
 
         if self.key:
             return '{}/{key}/'.format(

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -169,12 +169,12 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         return_value=Response(fixture='dcim/devices.json')
     )
     def test_multi_filter(self, mock):
-        ret = getattr(nb, self.name).filter(role=['test', 'test1'], site='TEST1')
+        ret = getattr(nb, self.name).filter(role=['test', 'test1'], site='TEST#1')
         self.assertTrue(ret)
         self.assertTrue(isinstance(ret, list))
         self.assertTrue(isinstance(ret[0], self.ret))
         mock.assert_called_with(
-            'http://localhost:8000/api/{}/{}/?role=test&role=test1&site=TEST1'.format(
+            'http://localhost:8000/api/{}/{}/?role=test&role=test1&site=TEST%231'.format(
                 self.app,
                 self.name.replace('_', '-')
             ),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -10,5 +10,6 @@ class TestQuery(unittest.TestCase):
         test_params = OrderedDict([
             ('abc', '123'),
             ('xyz', '321'),
+            ('enc', '#12'),
         ])
-        self.assertEqual(url_param_builder(test_params), '?abc=123&xyz=321')
+        self.assertEqual(url_param_builder(test_params), '?abc=123&xyz=321&enc=%2312')


### PR DESCRIPTION
fixes #52 
- This fixes some problems with urls that were not encoded, causing devices with characters in the name (like `#`) to not be retrieved through pynetbox.
