### PR TITLE
`netaddr` usage

### DIFF
--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
-import netaddr
 import six
+import ipaddress
 
 from pynetbox.lib.query import Request
 
@@ -200,8 +200,8 @@ class Record(object):
             if isinstance(current_val, Record):
                 current_val = getattr(current_val, 'serialize')(nested=True)
 
-            if isinstance(current_val, netaddr.ip.IPNetwork):
-                current_val = str(current_val)
+            if isinstance(current_val, ipaddress._IPAddressBase):
+                current_val = current_val.exploded
 
             ret.update({i: current_val})
         return ret
@@ -265,7 +265,7 @@ class IPRecord(Record):
     """IP-specific Record for IPAM responses.
 
     Extends ``Record`` objects to handle replacing ip4/6 strings with
-    instances of ``netaddr.IPNetworks`` instead.
+    instances of ``ipaddress.IPv*Networks`` instead.
     """
 
     def __init__(self, *args, **kwargs):
@@ -278,8 +278,8 @@ class IPRecord(Record):
             if isinstance(cur_attr, Record):
                 yield i, dict(cur_attr)
             else:
-                if isinstance(cur_attr, netaddr.IPNetwork):
-                    yield i, str(cur_attr)
+                if isinstance(cur_attr, ipaddress._IPAddressBase):
+                    yield i, cur_attr.exploded
                 else:
                     yield i, cur_attr
 
@@ -299,8 +299,8 @@ class IPRecord(Record):
                         v = self.default_ret(v, api_kwargs=self.api_kwargs)
                 if isinstance(v, six.string_types):
                     try:
-                        v = netaddr.IPNetwork(v)
-                    except netaddr.AddrFormatError:
+                        v = ipaddress.ip_interface(v)
+                    except ValueError:
                         pass
                 self._add_cache((k, v))
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-netaddr==0.7.18
+ipaddress; python_version < '3.3'
 requests==2.10.0
 six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
         'pynetbox.lib'
     ],
     install_requires=[
-        'netaddr==0.7.18',
         'requests==2.10.0',
-        'six==1.11.0'
+        'six==1.11.0',
+        'ipaddress;python_version<"3.3"'
     ],
     zip_safe=False,
     keywords=['netbox'],

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 
-import netaddr
+import ipaddress
 import six
 
 from .util import Response
@@ -100,9 +100,9 @@ class GenericTest(object):
             if self.ip_obj_fields:
                 for field in self.ip_obj_fields:
                     self.assertTrue(
-                        isinstance(getattr(ret, field), netaddr.IPNetwork)
+                        isinstance(getattr(ret, field), ipaddress._IPAddressBase)
                     )
-                    self.assertTrue(netaddr.IPNetwork(dict(ret)[field]))
+                    self.assertTrue(ipaddress.ip_interface(dict(ret)[field]))
 
 
 class PrefixTestCase(unittest.TestCase, GenericTest):
@@ -116,12 +116,12 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
     )
     def test_modify(self, mock):
         ret = nb.prefixes.get(1)
-        ret.prefix = '10.1.2.0/24'
+        ret.prefix = u'10.1.2.0/24'
         ret_serialized = ret.serialize()
         self.assertTrue(ret_serialized)
         self.assertFalse(ret._compare())
         self.assertEqual(ret_serialized['prefix'], '10.1.2.0/24')
-        self.assertTrue(netaddr.IPNetwork(ret_serialized['prefix']))
+        self.assertTrue(ipaddress.ip_interface(ret_serialized['prefix']))
 
     @patch(
         'pynetbox.lib.query.requests.get',
@@ -229,7 +229,7 @@ class IPAddressTestCase(unittest.TestCase, GenericTest):
         self.assertFalse(ret._compare())
         self.assertEqual(ret_serialized['address'], '10.0.255.1/32')
         self.assertEqual(ret_serialized['description'], 'testing')
-        self.assertTrue(netaddr.IPNetwork(ret_serialized['address']))
+        self.assertTrue(ipaddress.ip_interface(ret_serialized['address']))
 
 
 class RoleTestCase(unittest.TestCase, GenericTest):


### PR DESCRIPTION
This is more of an issue than a pull request...We noticed that Pynetbox was using `netaddr` instead of `ipaddress`, and were wondering if there's a specific reason for that. Is it more extensible, or does it provide better Py3 compatibility or something similar?

As a proof-of-concept, here's a patch that converts netbox to use `ipaddress` (built in from Python3.3+, a PyPI module for earlier version) if you want to try it out.