### PR TITLE
Fixes #61 - URL with trailing frontslash

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -89,7 +89,7 @@ class Api(object):
             raise ValueError(
                 '"private_key" and "private_key_file" cannot be used together.'
             )
-        base_url = "{}/api".format(url)
+        base_url = "{}/api".format(url if url[-1] != '/' else url[:-1])
 
         self.api_kwargs = {
             "token": token,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,6 +41,18 @@ class ApiTestCase(unittest.TestCase):
         )
         self.assertTrue(api)
 
+    @patch(
+        'pynetbox.lib.query.requests.post',
+        return_value=Response(fixture='api/get_session_key.json')
+    )
+    def test_sanitize_url(self, mock):
+        api = pynetbox.api(
+            'http://localhost:8000/',
+            **def_kwargs
+        )
+        self.assertTrue(api)
+        self.assertEqual(api.api_kwargs['base_url'], 'http://localhost:8000/api')
+
 
 class ApiArgumentsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Sanitizes the url positional argument given to Api() to remove a trailing frontslash if it's passed.