### PR TITLE
Remove setuptools-scm requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         'netaddr==0.*',
         'requests==2.*',
         'six==1.*',
-        'setuptools-scm==2.*'
     ],
     zip_safe=False,
     keywords=['netbox'],


### PR DESCRIPTION
7c8e2efab8ec593b0b3d318446439f51768f5c86 removed the need for setuptools-scm, so it would be good to remove it from the `install_requires`.