### PR TITLE
Custom field serialization

### DIFF
--- a/tests/fixtures/dcim/site.json
+++ b/tests/fixtures/dcim/site.json
@@ -13,7 +13,11 @@
     "contact_email": "",
     "comments": "",
     "custom_fields": {
-        "test_custom": "Hello"
+        "test_custom": "Hello",
+        "test_selection": {
+            "value": 2,
+            "label": "second"
+        }
     },
     "count_prefixes": 2,
     "count_vlans": 1,

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -298,7 +298,7 @@ class SiteTestCase(unittest.TestCase, GenericTest):
         return_value=Response(fixture='dcim/site.json')
     )
     def test_custom_selection_serializer(self, _):
-        '''Test that serializer with custom selection fields.
+        '''Tests serializer with custom selection fields.
         '''
         ret = getattr(nb, self.name).get(1)
         ret.custom_fields['test_custom'] = "Testing"

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -282,7 +282,7 @@ class SiteTestCase(unittest.TestCase, GenericTest):
         'pynetbox.lib.query.requests.get',
         return_value=Response(fixture='dcim/site.json')
     )
-    def test_modify(self, mock):
+    def test_modify_custom(self, mock):
         '''Test modifying a custom field.
         '''
         ret = getattr(nb, self.name).get(1)
@@ -291,6 +291,23 @@ class SiteTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(ret.serialize())
         self.assertEqual(
             ret.custom_fields['test_custom'], 'Testing'
+        )
+
+    @patch(
+        'pynetbox.lib.query.requests.get',
+        return_value=Response(fixture='dcim/site.json')
+    )
+    def test_custom_selection_serializer(self, _):
+        '''Test that serializer with custom selection fields.
+        '''
+        ret = getattr(nb, self.name).get(1)
+        ret.custom_fields['test_custom'] = "Testing"
+        test = ret.serialize()
+        from pprint import pprint
+        pprint(test)
+        self.assertEqual(
+            test['custom_fields']['test_selection'],
+            2
         )
 
     @patch(


### PR DESCRIPTION
Flattens custom_fields in _compare() and serialize() methods so that selection type custom fields are formatted correctly.
