### PR TITLE
Return id when name and label aren't present. 

### DIFF
--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -100,9 +100,10 @@ class Record(object):
         return item
 
     def __str__(self):
-        return (
+        return str(
             getattr(self, 'name', None) or
             getattr(self, 'label', None) or
+            getattr(self, 'id', None) or
             ''
         )
 


### PR DESCRIPTION
For example on api/circuits/circuits endpoint only returns id, cid. No name or label, so you would get an array that looked like:

```
[, , , , , ]
```