### PR TITLE
Fixes #83 - Slashes in IP Description causes Exception

### DIFF
--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -332,7 +332,7 @@ class IPRecord(Record):
                 if isinstance(v, six.string_types):
                     try:
                         v = netaddr.IPNetwork(v)
-                    except netaddr.AddrFormatError:
+                    except (netaddr.AddrFormatError, ValueError):
                         pass
                 self._add_cache((k, v))
             else:


### PR DESCRIPTION
Adds ValueErrors to the list of exceptions that pass through the netaddr process due to netaddr returning a ValueError instead of a AddrFormatError when given certain input.