### PR TITLE
Fixes config context

### DIFF
--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -18,6 +18,10 @@ import six
 
 from pynetbox.lib.query import Request
 
+# List of fields that contain a dict but are not to be converted into
+# Record objects.
+JSON_FIELDS = ('custom_fields', 'data', 'config_context')
+
 
 def get_return(lookup, return_fields=None):
     '''Returns simple representations for items passed to lookup.
@@ -147,7 +151,8 @@ class Record(object):
         values within.
         """
         for k, v in values.items():
-            if k != 'custom_fields':
+
+            if k not in JSON_FIELDS:
                 if isinstance(v, dict):
                     lookup = getattr(self.__class__, k, None)
                     if lookup:

--- a/tests/fixtures/dcim/device.json
+++ b/tests/fixtures/dcim/device.json
@@ -65,5 +65,8 @@
     },
     "primary_ip6": null,
     "comments": "",
-    "custom_fields": {}
+    "custom_fields": {},
+    "config_context": {
+        "test_key": "test_val"
+    }
 }

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -161,6 +161,8 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(isinstance(ret, self.ret))
         self.assertTrue(isinstance(ret.primary_ip, pynetbox.ipam.IpAddresses))
         self.assertTrue(isinstance(ret.primary_ip4, pynetbox.ipam.IpAddresses))
+        self.assertTrue(isinstance(ret.config_context, dict))
+        self.assertTrue(isinstance(ret.custom_fields, dict))
         mock.assert_called_with(
             'http://localhost:8000/api/{}/{}/1/'.format(
                 self.app,


### PR DESCRIPTION
Expands the nested Record creation exception to include the "data" and "config_context" fields in addition to the "config_context" field. Added a constant called "JSON_FIELDS" that contains the names of any fields that contain dicts but should not be converted into Record objects.