### PR TITLE
using requests.Session for Request

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 '''
+from requests import Session
 from pynetbox.lib import Endpoint, Request
 from pynetbox import dcim, ipam, virtualization, circuits
 
@@ -90,6 +91,7 @@ class Api(object):
                 '"private_key" and "private_key_file" cannot be used together.'
             )
         base_url = "{}/api".format(url if url[-1] != '/' else url[:-1])
+        requests_session = Session()
 
         self.api_kwargs = {
             "token": token,
@@ -97,6 +99,7 @@ class Api(object):
             "private_key_file": private_key_file,
             "base_url": base_url,
             "ssl_verify": ssl_verify,
+            "requests_session": requests_session,
         }
 
         if self.api_kwargs.get('private_key_file'):
@@ -112,7 +115,8 @@ class Api(object):
             base=base_url,
             token=token,
             private_key=private_key,
-            ssl_verify=ssl_verify
+            ssl_verify=ssl_verify,
+            requests_session = requests_session
         )
         if token and private_key:
             self.api_kwargs.update(session_key=req.get_session_key())

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -116,7 +116,7 @@ class Api(object):
             token=token,
             private_key=private_key,
             ssl_verify=ssl_verify,
-            requests_session = requests_session
+            requests_session=requests_session
         )
         if token and private_key:
             self.api_kwargs.update(session_key=req.get_session_key())

--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -55,6 +55,7 @@ class Endpoint(object):
         self.version = api_kwargs.get('version')
         self.session_key = api_kwargs.get('session_key')
         self.ssl_verify = api_kwargs.get('ssl_verify')
+        self.requests_session = api_kwargs.get('requests_session')
         self.url = '{base_url}/{app}/{endpoint}'.format(
             base_url=self.base_url,
             app=app_name,
@@ -109,6 +110,7 @@ class Endpoint(object):
             session_key=self.session_key,
             version=self.version,
             ssl_verify=self.ssl_verify,
+            requests_session=self.requests_session,
         )
         ret_kwargs = dict(
             api_kwargs=self.api_kwargs,
@@ -167,6 +169,7 @@ class Endpoint(object):
             session_key=self.session_key,
             version=self.version,
             ssl_verify=self.ssl_verify,
+            requests_session=self.requests_session,
         )
         ret_kwargs = dict(
             api_kwargs=self.api_kwargs,
@@ -228,6 +231,7 @@ class Endpoint(object):
             session_key=self.session_key,
             version=self.version,
             ssl_verify=self.ssl_verify,
+            requests_session=self.requests_session,
         )
         ret_kwargs = dict(
             api_kwargs=self.api_kwargs,
@@ -296,6 +300,7 @@ class Endpoint(object):
             session_key=self.session_key,
             version=self.version,
             ssl_verify=self.ssl_verify,
+            requests_session=self.requests_session,
         ).post(args[0] if len(args) > 0 else kwargs)
 
 
@@ -311,6 +316,7 @@ class DetailEndpoint(object):
         self.version = parent_obj.api_kwargs.get('version')
         self.session_key = parent_obj.api_kwargs.get('session_key')
         self.ssl_verify = parent_obj.api_kwargs.get('ssl_verify')
+        self.requests_session = parent_obj.api_kwargs.get('requests_session')
         self.url = "{}/{}/{}/".format(
             parent_obj.endpoint_meta.get('url'),
             parent_obj.id,
@@ -322,6 +328,7 @@ class DetailEndpoint(object):
             session_key=self.session_key,
             version=self.version,
             ssl_verify=self.ssl_verify,
+            requests_session=self.requests_session,
         )
 
     def list(self, **kwargs):

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -47,6 +47,7 @@ class RequestError(Exception):
 
 
     """
+
     def __init__(self, message):
         req = message
         message = "The request failed with code {} {}".format(
@@ -100,7 +101,7 @@ class Request(object):
         self.session_key = session_key
         self.ssl_verify = ssl_verify
         self.requests = requests.Session() if requests_session is None \
-                                           else requests_session
+            else requests_session
 
     def get_version(self):
         """Query the netbox API for its API-Version.
@@ -149,6 +150,7 @@ class Request(object):
 
         :Returns: String of URL.
         """
+
         def construct_url(input):
             for k, v in input.items():
                 if isinstance(v, list):

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -99,7 +99,8 @@ class Request(object):
         self.version = version
         self.session_key = session_key
         self.ssl_verify = ssl_verify
-        self.requests = requests.Session() if requests_session is None else requests_session
+        self.requests = requests.Session() if requests_session is None \
+                                           else requests_session
 
     def get_version(self):
         """Query the netbox API for its API-Version.
@@ -213,7 +214,8 @@ class Request(object):
 
         def make_request(url):
 
-            req = self.requests.get(url, headers=headers, verify=self.ssl_verify)
+            req = self.requests.get(url, headers=headers,
+                                    verify=self.ssl_verify)
             if req.ok:
                 return req.json()
             else:
@@ -262,9 +264,9 @@ class Request(object):
                 {'X-Session-Key': self.session_key}
             )
         req = self.requests.put(self.url,
-                           headers=headers,
-                           data=json.dumps(data),
-                           verify=self.ssl_verify)
+                                headers=headers,
+                                data=json.dumps(data),
+                                verify=self.ssl_verify)
         if req.ok:
             return req.json()
         else:

--- a/pynetbox/lib/query.py
+++ b/pynetbox/lib/query.py
@@ -77,7 +77,7 @@ class Request(object):
 
     def __init__(self, base=None, filters=None, key=None, token=None,
                  private_key=None, version=None, session_key=None,
-                 ssl_verify=True):
+                 ssl_verify=True, requests_session=None):
         """
         Instantiates a new Request object
 
@@ -99,6 +99,7 @@ class Request(object):
         self.version = version
         self.session_key = session_key
         self.ssl_verify = ssl_verify
+        self.requests = requests.Session() if requests_session is None else requests_session
 
     def get_version(self):
         """Query the netbox API for its API-Version.
@@ -107,7 +108,7 @@ class Request(object):
 
         :returns: String containing version.
         """
-        ret = requests.get(
+        ret = self.requests.get(
             "{}/".format(self.base),
             verify=self.ssl_verify
         ).headers.get('API-Version', '1.0')
@@ -122,7 +123,7 @@ class Request(object):
 
         :Returns: String containing session key.
         """
-        req = requests.post(
+        req = self.requests.post(
             '{}/secrets/get-session-key/?preserve_key=True'.format(self.base),
             headers={
                 'accept': 'application/json',
@@ -212,7 +213,7 @@ class Request(object):
 
         def make_request(url):
 
-            req = requests.get(url, headers=headers, verify=self.ssl_verify)
+            req = self.requests.get(url, headers=headers, verify=self.ssl_verify)
             if req.ok:
                 return req.json()
             else:
@@ -260,7 +261,7 @@ class Request(object):
             headers.update(
                 {'X-Session-Key': self.session_key}
             )
-        req = requests.put(self.url,
+        req = self.requests.put(self.url,
                            headers=headers,
                            data=json.dumps(data),
                            verify=self.ssl_verify)
@@ -290,7 +291,7 @@ class Request(object):
             headers.update(
                 {'X-Session-Key': self.session_key}
             )
-        req = requests.post(
+        req = self.requests.post(
             self.normalize_url(self.url),
             headers=headers,
             data=json.dumps(data),
@@ -319,7 +320,7 @@ class Request(object):
             ),
             'authorization': 'Token {}'.format(self.token),
         }
-        req = requests.delete(
+        req = self.requests.delete(
             "{}".format(self.url),
             headers=headers,
             verify=self.ssl_verify

--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -202,7 +202,8 @@ class Record(object):
                 token=self.api_kwargs.get('token'),
                 session_key=self.api_kwargs.get('session_key'),
                 version=self.api_kwargs.get('version'),
-                ssl_verify=self.api_kwargs.get('ssl_verify')
+                ssl_verify=self.api_kwargs.get('ssl_verify'),
+                requests_session=self.api_kwargs.get('requests_session')
             )
             self._parse_values(req.get())
             self.has_details = True
@@ -266,7 +267,8 @@ class Record(object):
                     token=self.api_kwargs.get('token'),
                     session_key=self.api_kwargs.get('session_key'),
                     version=self.api_kwargs.get('version'),
-                    ssl_verify=self.api_kwargs.get('ssl_verify')
+                    ssl_verify=self.api_kwargs.get('ssl_verify'),
+                    requests_session=self.api_kwargs.get('requests_session')
                 )
                 if req.put(self.serialize()):
                     return True
@@ -290,7 +292,8 @@ class Record(object):
             token=self.api_kwargs.get('token'),
             session_key=self.api_kwargs.get('session_key'),
             version=self.api_kwargs.get('version'),
-            ssl_verify=self.api_kwargs.get('ssl_verify')
+            ssl_verify=self.api_kwargs.get('ssl_verify'),
+            requests_session=self.api_kwargs.get('requests_session')
         )
         if req.delete():
             return True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ endpoints = {
 class ApiTestCase(unittest.TestCase):
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='api/get_session_key.json')
     )
     def test_get(self, mock):
@@ -42,7 +42,7 @@ class ApiTestCase(unittest.TestCase):
         self.assertTrue(api)
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='api/get_session_key.json')
     )
     def test_sanitize_url(self, mock):
@@ -57,7 +57,7 @@ class ApiTestCase(unittest.TestCase):
 class ApiArgumentsTestCase(unittest.TestCase):
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='api/get_session_key.json')
     )
     def common_arguments(self, kwargs, arg, expect, mock):

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -28,7 +28,7 @@ class GenericTest(object):
 
     def test_get_all(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -49,7 +49,7 @@ class GenericTest(object):
 
     def test_filter(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -70,7 +70,7 @@ class GenericTest(object):
 
     def test_get(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]
@@ -93,7 +93,7 @@ class CircuitsTestCase(unittest.TestCase, GenericTest):
     name = 'circuits'
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='circuits/circuit.json')
     )
     def test_repr(self, _):
@@ -113,7 +113,7 @@ class CircuitTerminationsTestCase(unittest.TestCase, GenericTest):
     name = 'circuit_terminations'
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='circuits/circuit_termination.json')
     )
     def test_repr(self, _):

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -34,7 +34,7 @@ class GenericTest(object):
 
     def test_get_all(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -55,7 +55,7 @@ class GenericTest(object):
 
     def test_filter(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -76,7 +76,7 @@ class GenericTest(object):
 
     def test_get(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]
@@ -98,12 +98,12 @@ class GenericTest(object):
 
     def test_delete(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]
             ))
-        ) as mock, patch('pynetbox.lib.query.requests.delete') as delete:
+        ) as mock, patch('pynetbox.lib.query.requests.Session.delete') as delete:
             ret = getattr(nb, self.name).get(1)
             self.assertTrue(ret.delete())
             mock.assert_called_with(
@@ -125,7 +125,7 @@ class GenericTest(object):
 
     def test_compare(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]
@@ -137,7 +137,7 @@ class GenericTest(object):
 
     def test_serialize(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]
@@ -152,7 +152,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
     name = 'devices'
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/device.json')
     )
     def test_get(self, mock):
@@ -173,7 +173,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         )
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/devices.json')
     )
     def test_multi_filter(self, mock):
@@ -191,7 +191,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         )
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/device.json')
     )
     def test_modify(self, mock):
@@ -203,7 +203,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         self.assertEqual(ret_serialized['serial'], '123123123123')
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='dcim/device.json')
     )
     def test_create(self, mock):
@@ -217,7 +217,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(ret)
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='dcim/device_bulk_create.json')
     )
     def test_create_device_bulk(self, mock):
@@ -240,7 +240,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(len(ret), 2)
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         side_effect=[
             Response(fixture='dcim/device.json'),
             Response(fixture='dcim/rack.json'),
@@ -259,7 +259,7 @@ class DeviceTestCase(unittest.TestCase, GenericTest):
         ))
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         side_effect=[
             Response(fixture='dcim/device.json'),
             Response(fixture='dcim/napalm.json'),
@@ -281,7 +281,7 @@ class SiteTestCase(unittest.TestCase, GenericTest):
     name = 'sites'
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/site.json')
     )
     def test_modify_custom(self, mock):
@@ -296,7 +296,7 @@ class SiteTestCase(unittest.TestCase, GenericTest):
         )
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/site.json')
     )
     def test_custom_selection_serializer(self, _):
@@ -313,7 +313,7 @@ class SiteTestCase(unittest.TestCase, GenericTest):
         )
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='dcim/site.json')
     )
     def test_create(self, mock):
@@ -331,7 +331,7 @@ class InterfaceTestCase(unittest.TestCase, GenericTest):
     name = 'interfaces'
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/interface.json')
     )
     def test_modify(self, mock):
@@ -343,7 +343,7 @@ class InterfaceTestCase(unittest.TestCase, GenericTest):
         self.assertEqual(ret_serialized['form_factor'], 1400)
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='dcim/interface.json')
     )
     def test_modify_connected_iface(self, mock):
@@ -359,7 +359,7 @@ class InterfaceTestCase(unittest.TestCase, GenericTest):
         )
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         side_effect=[
             Response(fixture='dcim/{}.json'.format(name + '_1')),
             Response(fixture='dcim/{}.json'.format(name + '_2')),

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -39,7 +39,7 @@ class GenericTest(object):
 
     def test_get_all(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -60,7 +60,7 @@ class GenericTest(object):
 
     def test_filter(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -81,7 +81,7 @@ class GenericTest(object):
 
     def test_get(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name_singular or self.name[:-1]
@@ -114,7 +114,7 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
     ip_obj_fields = ['prefix']
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='ipam/prefix.json')
     )
     def test_modify(self, mock):
@@ -127,11 +127,11 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(netaddr.IPNetwork(ret_serialized['prefix']))
 
     @patch(
-        'pynetbox.lib.query.requests.put',
+        'pynetbox.lib.query.requests.Session.put',
         return_value=Response(fixture='ipam/prefix.json')
     )
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='ipam/prefix.json')
     )
     def test_idempotence(self, *_):
@@ -140,7 +140,7 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         self.assertFalse(test)
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         side_effect=[
             Response(fixture='ipam/prefix.json'),
             Response(fixture='ipam/available-ips.json'),
@@ -158,11 +158,11 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         self.assertEqual(len(ret), 3)
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='ipam/available-ips-post.json')
     )
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='ipam/prefix.json'),
     )
     def test_create_available_ips(self, get, post):
@@ -193,7 +193,7 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         self.assertEqual(ret, expected_result)
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         side_effect=[
             Response(fixture='ipam/prefix.json'),
             Response(fixture='ipam/available-prefixes.json'),
@@ -210,11 +210,11 @@ class PrefixTestCase(unittest.TestCase, GenericTest):
         self.assertTrue(ret)
 
     @patch(
-        'pynetbox.lib.query.requests.post',
+        'pynetbox.lib.query.requests.Session.post',
         return_value=Response(fixture='ipam/available-prefixes-post.json')
     )
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='ipam/prefix.json'),
     )
     def test_create_available_prefixes(self, get, post):
@@ -238,7 +238,7 @@ class IPAddressTestCase(unittest.TestCase, GenericTest):
     ip_obj_fields = ['address']
 
     @patch(
-        'pynetbox.lib.query.requests.get',
+        'pynetbox.lib.query.requests.Session.get',
         return_value=Response(fixture='ipam/ip_address.json')
     )
     def test_modify(self, mock):

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -29,7 +29,7 @@ class GenericTest(object):
 
     def test_get_all(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -50,7 +50,7 @@ class GenericTest(object):
 
     def test_filter(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -71,7 +71,7 @@ class GenericTest(object):
 
     def test_get(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -29,7 +29,7 @@ class GenericTest(object):
 
     def test_get_all(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -50,7 +50,7 @@ class GenericTest(object):
 
     def test_filter(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name
@@ -71,7 +71,7 @@ class GenericTest(object):
 
     def test_get(self):
         with patch(
-            'pynetbox.lib.query.requests.get',
+            'pynetbox.lib.query.requests.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 self.app,
                 self.name[:-1]


### PR DESCRIPTION
While using pynetbox for big amount of small changes in our netbox database I noticed an annoying latency. A college had a look to the network traffic and told me, that for every request a single http session gets initialized, used and closed.

This PR uses the onboard http sessions from requests. initialized in Api() and used by Request(). It speeds up the communication by (re-)using a single http session per Api objects including keep-alive. The improvement is around 25%