### PR TITLE
Fixes #94 - Tag idempotence

### DIFF
--- a/pynetbox/lib/response.py
+++ b/pynetbox/lib/response.py
@@ -238,6 +238,8 @@ class Record(object):
             current_val = getattr(self, i)
             if i == 'custom_fields':
                 ret[i] = flatten_custom(current_val)
+            elif i == 'tags':
+                ret[i] = list(set(current_val))
             else:
                 if isinstance(current_val, Record):
                     current_val = getattr(

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -37,3 +37,15 @@ class RecordTestCase(unittest.TestCase):
         test_obj = Record(test_values)
         test = test_obj.serialize()
         self.assertEqual(test['units'], [12])
+
+    def test_serialize_tag_set(self):
+        test_values = {
+            'id': 123,
+            'tags': [
+                'foo',
+                'bar',
+                'foo',
+            ]
+        }
+        test = Record(test_values).serialize()
+        self.assertEqual(len(test['tags']), 2)


### PR DESCRIPTION
converts tags into a set then a list in serialize() so that updates of
the same value don't break idempotence. Also adds a place to start
putting unit tests beginning with Record.serialize() to test handling tags as a set.