### PR TITLE
TypeError: sequence item 0: expected str instance.

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -326,7 +326,7 @@ class Record(object):
             if isinstance(v, dict):
                 return k, Hashabledict(v)
             if isinstance(v, list):
-                return k, "".join(v)
+                return k, "".join(map(str, v))
             return k, v
 
         current = Hashabledict(


### PR DESCRIPTION
If an array of integers, then we get an error:
File "/opt/ansible-py3.6/lib/python3.6/site-packages/pynetbox/core/response.py", line 329, in fmt_dict
    return k, "".join(v)
TypeError: sequence item 0: expected str instance, int found

Just convert to string.
I got an error when there are vlans on the interface.