### PR TITLE
Fixes #127 - Record iter doesn't handle list of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+v4.0.3 (2018-12-07)
+
+## Bug Fixes
+* [#127](https://github.com/digitalocean/pynetbox/issues/127) - Fixes `__iter__` method on Record object so that it properly return lists record objects. Like tagged_vlans on for Interfaces.
+
+---
+
 v4.0.2 (2018-12-06)
 
 ## Bug Fixes

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -183,6 +183,10 @@ class Record(object):
             cur_attr = getattr(self, i)
             if isinstance(cur_attr, Record):
                 yield i, dict(cur_attr)
+            elif isinstance(cur_attr, list) and isinstance(
+                cur_attr[0], Record
+            ):
+                yield i, [dict(x) for x in cur_attr]
             else:
                 yield i, cur_attr
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -77,3 +77,56 @@ class RecordTestCase(unittest.TestCase):
         test.nested_dict = 1
         test.string_field = 'foobaz'
         self.assertEqual(test._diff(), {'tags', 'nested_dict', 'string_field'})
+
+    def test_dict(self):
+        test_values = {
+            'id': 123,
+            'custom_fields': {
+                'foo': 'bar'
+            },
+            'string_field': 'foobar',
+            'int_field': 1,
+            "nested_dict": {
+                "id": 222,
+                "name": 'bar',
+            },
+            'tags': [
+                'foo',
+                'bar',
+            ],
+            'int_list': [
+                123,
+                321,
+                231,
+            ],
+            'record_list': [
+                {
+                    'id': 123,
+                    'name': 'Test',
+                    'str_attr': 'foo',
+                    'int_attr': 123,
+                    'custom_fields': {
+                        'foo': 'bar'
+                    },
+                    'tags': [
+                        'foo',
+                        'bar',
+                    ],
+                },
+                {
+                    'id': 321,
+                    'name': 'Test 1',
+                    'str_attr': 'bar',
+                    'int_attr': 321,
+                    'custom_fields': {
+                        'foo': 'bar'
+                    },
+                    'tags': [
+                        'foo',
+                        'bar',
+                    ],
+                },
+            ]
+        }
+        test = Record(test_values, None, None)
+        self.assertEqual(dict(test), test_values)


### PR DESCRIPTION
Fixes __iter__ method on Record object to properly return lists of other record objects. Like tagged_vlans on Interface objects.