### PR TITLE
Сertain sequence vlan id

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -330,7 +330,7 @@ class Record(object):
             if isinstance(v, dict):
                 return k, Hashabledict(v)
             if isinstance(v, list):
-                return k, "".join(map(str, v))
+                return k, ",".join(map(str, v))
             return k, v
 
         current = Hashabledict(


### PR DESCRIPTION
If you transfer for example 2 vlans with id 45 and 46, and then change to 4 and 546 then diff will not dispel the change.
The result in both cases will be 4546.