### PR TITLE
Single TCP Session for HTTP Requests

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -46,6 +46,7 @@ class App(object):
             return self._choices
 
         self._choices = Request(
+            api=self.api,
             base="{}/{}/_choices/".format(self.api.base_url, self.name),
             token=self.api.token,
             private_key=self.api.private_key,
@@ -118,12 +119,15 @@ class Api(object):
         self.ssl_verify = ssl_verify
         self.session_key = None
 
+        self.session = requests.Session()
+
         if self.private_key_file:
             with open(self.private_key_file, "r") as kf:
                 private_key = kf.read()
                 self.private_key = private_key
 
         req = Request(
+            api=self,
             base=base_url,
             token=token,
             private_key=private_key,

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -17,6 +17,8 @@ from pynetbox.core.endpoint import Endpoint
 from pynetbox.core.query import Request
 from pynetbox.models import dcim, ipam, virtualization, circuits
 
+import requests
+
 
 class App(object):
     """ Represents apps in NetBox.

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -89,6 +89,7 @@ class Endpoint(object):
         >>>
         """
         req = Request(
+            api=self.api,
             base="{}/".format(self.url),
             token=self.token,
             session_key=self.session_key,
@@ -145,6 +146,7 @@ class Endpoint(object):
             return None
 
         req = Request(
+            api=self.api,
             key=key,
             base=self.url,
             token=self.token,
@@ -210,6 +212,7 @@ class Endpoint(object):
             )
 
         req = Request(
+            api=self.api,
             filters=kwargs,
             base=self.url,
             token=self.token,
@@ -272,6 +275,7 @@ class Endpoint(object):
         """
 
         req = Request(
+            api=self.api,
             base=self.url,
             token=self.token,
             session_key=self.session_key,

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -16,8 +16,6 @@ limitations under the License.
 import json
 from six.moves.urllib.parse import urlencode
 
-import requests
-
 
 def url_param_builder(param_dict):
     """Builds url parameters

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -90,6 +90,7 @@ class Request(object):
 
     def __init__(
         self,
+        api=None,
         base=None,
         filters=None,
         key=None,
@@ -111,6 +112,7 @@ class Request(object):
             private_key (string, optional): The user's private key as a
                 string.
         """
+        self.api = api
         self.base = base
         self.filters = filters
         self.key = key
@@ -127,7 +129,7 @@ class Request(object):
 
         :Returns: String containing session key.
         """
-        req = requests.post(
+        req = self.api.session.post(
             "{}/secrets/get-session-key/?preserve_key=True".format(self.base),
             headers={
                 "accept": "application/json",
@@ -206,8 +208,11 @@ class Request(object):
             headers.update({"X-Session-Key": self.session_key})
 
         def make_request(url):
-
-            req = requests.get(url, headers=headers, verify=self.ssl_verify)
+            req = self.api.session.get(
+                url,
+                headers=headers,
+                verify=self.ssl_verify,
+            )
             if req.ok:
                 return req.json()
             else:
@@ -255,7 +260,7 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
-        req = requests.put(
+        req = self.api.session.put(
             self.url,
             headers=headers,
             data=json.dumps(data),
@@ -283,7 +288,7 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
-        req = requests.post(
+        req = self.api.session.post(
             self.normalize_url(self.url),
             headers=headers,
             data=json.dumps(data),
@@ -309,7 +314,7 @@ class Request(object):
             "accept": "application/json;",
             "authorization": "Token {}".format(self.token),
         }
-        req = requests.delete(
+        req = self.api.session.delete(
             "{}".format(self.url), headers=headers, verify=self.ssl_verify
         )
         if req.ok:
@@ -333,7 +338,7 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
-        req = requests.patch(
+        req = self.api.session.patch(
             self.url,
             headers=headers,
             data=json.dumps(data),

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -274,6 +274,7 @@ class Record(object):
         """
         if self.url:
             req = Request(
+                api=self.api,
                 base=self.url,
                 token=self.api.token,
                 session_key=self.api.session_key,
@@ -366,6 +367,7 @@ class Record(object):
             if diff:
                 serialized = self.serialize()
                 req = Request(
+                    api=self.api,
                     key=self.id,
                     base=self.endpoint.url,
                     token=self.api.token,
@@ -414,6 +416,7 @@ class Record(object):
         >>>
         """
         req = Request(
+            api=self.api,
             key=self.id,
             base=self.endpoint.url,
             token=self.api.token,


### PR DESCRIPTION
Instead of establishing an entirely new TCP session and closing it for each individual request, only one session is created. 

This approach saves a lot of time. To be more accurate, for every individual request after the first one that created the socket, the following packets will not be sent (S) or received (R):
- (S) SYN 
- (R) SYN-ACK
- (S) ACK
- (S) FIN
- (R) FIN

I've ran a test (pull list 100 times back-to-back) multiple times in a controlled environment (set the delay to 20ms in VMware) and the results are:
- One TCP session per request: 7.536s
- One TCP session for all requests: 4.712s

The savings here aren't necessarily on the bandwidth aspect, but the delay one; all of the above packets are blocking (the client/server must wait until the corresponding packet is sent/received).

Furthermore, the delay in the test was set 20ms. The higher the delay and/or the volume of requests, the worse this effect becomes.