### PR TITLE
add requests http session to Api, to Request and usage of Request

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import requests
+
 from pynetbox.core.endpoint import Endpoint
 from pynetbox.core.query import Request
 from pynetbox.models import dcim, ipam, virtualization, circuits
@@ -50,6 +52,7 @@ class App(object):
             token=self.api.token,
             private_key=self.api.private_key,
             ssl_verify=self.api.ssl_verify,
+            http_session=self.api.http_session,
         ).get()
 
         return self._choices
@@ -117,6 +120,7 @@ class Api(object):
         self.base_url = base_url
         self.ssl_verify = ssl_verify
         self.session_key = None
+        self.http_session = requests.Session()
 
         if self.private_key_file:
             with open(self.private_key_file, "r") as kf:
@@ -128,6 +132,7 @@ class Api(object):
             token=token,
             private_key=private_key,
             ssl_verify=ssl_verify,
+            http_session = self.http_session
         )
         if self.token and self.private_key:
             self.session_key = req.get_session_key()

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -132,7 +132,7 @@ class Api(object):
             token=token,
             private_key=private_key,
             ssl_verify=ssl_verify,
-            http_session = self.http_session
+            http_session=self.http_session
         )
         if self.token and self.private_key:
             self.session_key = req.get_session_key()

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -306,6 +306,7 @@ class DetailEndpoint(object):
             token=parent_obj.api.token,
             session_key=parent_obj.api.session_key,
             ssl_verify=parent_obj.api.ssl_verify,
+            http_session=parent_obj.api.http_session,
         )
 
     def list(self, **kwargs):

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -93,6 +93,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            http_session=self.api.http_session,
         )
 
         return [self._response_loader(i) for i in req.get()]
@@ -150,6 +151,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            http_session=self.api.http_session,
         )
 
         return self._response_loader(req.get())
@@ -215,6 +217,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            http_session=self.api.http_session,
         )
 
         ret = [self._response_loader(i) for i in req.get()]
@@ -276,6 +279,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            http_session=self.api.http_session,
         ).post(args[0] if args else kwargs)
 
         if isinstance(req, list):

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -97,6 +97,7 @@ class Request(object):
         private_key=None,
         session_key=None,
         ssl_verify=True,
+        http_session=None,
     ):
         """
         Instantiates a new Request object
@@ -118,6 +119,7 @@ class Request(object):
         self.private_key = private_key
         self.session_key = session_key
         self.ssl_verify = ssl_verify
+        self.http_session = http_session
 
     def get_session_key(self):
         """Requests session key
@@ -127,7 +129,7 @@ class Request(object):
 
         :Returns: String containing session key.
         """
-        req = requests.post(
+        req = self.http_session.post(
             "{}/secrets/get-session-key/?preserve_key=True".format(self.base),
             headers={
                 "accept": "application/json",
@@ -207,7 +209,7 @@ class Request(object):
 
         def make_request(url):
 
-            req = requests.get(url, headers=headers, verify=self.ssl_verify)
+            req = self.http_session.get(url, headers=headers, verify=self.ssl_verify)
             if req.ok:
                 return req.json()
             else:
@@ -255,7 +257,7 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
-        req = requests.put(
+        req = self.http_session.put(
             self.url,
             headers=headers,
             data=json.dumps(data),
@@ -283,7 +285,7 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
-        req = requests.post(
+        req = self.http_session.post(
             self.normalize_url(self.url),
             headers=headers,
             data=json.dumps(data),
@@ -309,7 +311,7 @@ class Request(object):
             "accept": "application/json;",
             "authorization": "Token {}".format(self.token),
         }
-        req = requests.delete(
+        req = self.http_session.delete(
             "{}".format(self.url), headers=headers, verify=self.ssl_verify
         )
         if req.ok:
@@ -333,7 +335,7 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
-        req = requests.patch(
+        req = self.http_session.patch(
             self.url,
             headers=headers,
             data=json.dumps(data),

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -209,7 +209,8 @@ class Request(object):
 
         def make_request(url):
 
-            req = self.http_session.get(url, headers=headers, verify=self.ssl_verify)
+            req = self.http_session.get(url, headers=headers,
+                                        verify=self.ssl_verify)
             if req.ok:
                 return req.json()
             else:

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -278,6 +278,7 @@ class Record(object):
                 token=self.api.token,
                 session_key=self.api.session_key,
                 ssl_verify=self.api.ssl_verify,
+                http_session=self.api.http_session,
             )
             self._parse_values(req.get())
             self.has_details = True
@@ -371,6 +372,7 @@ class Record(object):
                     token=self.api.token,
                     session_key=self.api.session_key,
                     ssl_verify=self.api.ssl_verify,
+                    http_session=self.api.http_session,
                 )
                 if req.patch({i: serialized[i] for i in diff}):
                     return True
@@ -419,5 +421,6 @@ class Record(object):
             token=self.api.token,
             session_key=self.api.session_key,
             ssl_verify=self.api.ssl_verify,
+            http_session=self.api.http_session,
         )
         return True if req.delete() else False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,7 +30,7 @@ endpoints = {
 class ApiTestCase(unittest.TestCase):
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='api/get_session_key.json')
     )
     def test_get(self, *_):
@@ -41,7 +41,7 @@ class ApiTestCase(unittest.TestCase):
         self.assertTrue(api)
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='api/get_session_key.json')
     )
     def test_sanitize_url(self, *_):
@@ -56,7 +56,7 @@ class ApiTestCase(unittest.TestCase):
 class ApiArgumentsTestCase(unittest.TestCase):
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='api/get_session_key.json')
     )
     def common_arguments(self, kwargs, arg, expect, *_):

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -28,7 +28,7 @@ class Generic(object):
 
         def test_get_all(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -49,7 +49,7 @@ class Generic(object):
 
         def test_filter(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -70,7 +70,7 @@ class Generic(object):
 
         def test_get(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]
@@ -93,7 +93,7 @@ class CircuitsTestCase(Generic.Tests):
     name = 'circuits'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='circuits/circuit.json')
     )
     def test_repr(self, _):
@@ -113,7 +113,7 @@ class CircuitTerminationsTestCase(Generic.Tests):
     name = 'circuit_terminations'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='circuits/circuit_termination.json')
     )
     def test_repr(self, _):

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -34,7 +34,7 @@ class Generic(object):
 
         def test_get_all(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -55,7 +55,7 @@ class Generic(object):
 
         def test_filter(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -76,7 +76,7 @@ class Generic(object):
 
         def test_get(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]
@@ -98,12 +98,12 @@ class Generic(object):
 
         def test_delete(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]
                 ))
-            ) as mock, patch('pynetbox.core.query.requests.delete') as delete:
+            ) as mock, patch('pynetbox.core.query.requests.sessions.Session.delete') as delete:
                 ret = getattr(nb, self.name).get(1)
                 self.assertTrue(ret.delete())
                 mock.assert_called_with(
@@ -125,7 +125,7 @@ class Generic(object):
 
         def test_compare(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]
@@ -137,7 +137,7 @@ class Generic(object):
 
         def test_serialize(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]
@@ -152,7 +152,7 @@ class DeviceTestCase(Generic.Tests):
     name = 'devices'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='dcim/device.json')
     )
     def test_get(self, mock):
@@ -173,7 +173,7 @@ class DeviceTestCase(Generic.Tests):
         )
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='dcim/devices.json')
     )
     def test_multi_filter(self, mock):
@@ -191,7 +191,7 @@ class DeviceTestCase(Generic.Tests):
         )
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='dcim/device.json')
     )
     def test_modify(self, *_):
@@ -203,7 +203,7 @@ class DeviceTestCase(Generic.Tests):
         self.assertEqual(ret_serialized['serial'], '123123123123')
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='dcim/device.json')
     )
     def test_create(self, *_):
@@ -217,7 +217,7 @@ class DeviceTestCase(Generic.Tests):
         self.assertTrue(ret)
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='dcim/device_bulk_create.json')
     )
     def test_create_device_bulk(self, *_):
@@ -240,7 +240,7 @@ class DeviceTestCase(Generic.Tests):
         self.assertTrue(len(ret), 2)
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         side_effect=[
             Response(fixture='dcim/device.json'),
             Response(fixture='dcim/rack.json'),
@@ -259,7 +259,7 @@ class DeviceTestCase(Generic.Tests):
         ))
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         side_effect=[
             Response(fixture='dcim/device.json'),
             Response(fixture='dcim/napalm.json'),
@@ -281,7 +281,7 @@ class SiteTestCase(Generic.Tests):
     name = 'sites'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='dcim/site.json')
     )
     def test_modify_custom(self, *_):
@@ -296,7 +296,7 @@ class SiteTestCase(Generic.Tests):
         )
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='dcim/site.json')
     )
     def test_custom_selection_serializer(self, _):
@@ -311,7 +311,7 @@ class SiteTestCase(Generic.Tests):
         )
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='dcim/site.json')
     )
     def test_create(self, *_):
@@ -329,7 +329,7 @@ class InterfaceTestCase(Generic.Tests):
     name = 'interfaces'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='dcim/interface.json')
     )
     def test_modify(self, *_):
@@ -341,7 +341,7 @@ class InterfaceTestCase(Generic.Tests):
         self.assertEqual(ret_serialized['form_factor'], 1400)
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         side_effect=[
             Response(fixture='dcim/{}.json'.format(name + '_1')),
             Response(fixture='dcim/{}.json'.format(name + '_2')),
@@ -364,7 +364,7 @@ class RackTestCase(Generic.Tests):
     name = 'racks'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         side_effect=[
             Response(fixture='dcim/rack.json'),
             Response(fixture='dcim/rack_u.json'),
@@ -480,7 +480,7 @@ class Choices(unittest.TestCase):
 
     def test_get(self):
         with patch(
-            'pynetbox.core.query.requests.get',
+            'pynetbox.core.query.requests.sessions.Session.get',
             return_value=Response(fixture='{}/{}.json'.format(
                 'dcim',
                 'choices'
@@ -538,7 +538,7 @@ class CablesTestCase(Generic.Tests):
             "length_unit": None
         })
         with patch(
-            'pynetbox.core.query.requests.get',
+            'pynetbox.core.query.requests.sessions.Session.get',
             return_value=response_obj
         ) as mock:
             ret = getattr(nb, self.name).get(1)

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -37,7 +37,7 @@ class Generic(object):
 
         def test_get_all(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -58,7 +58,7 @@ class Generic(object):
 
         def test_filter(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -79,7 +79,7 @@ class Generic(object):
 
         def test_get(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name_singular or self.name[:-1]
@@ -105,7 +105,7 @@ class PrefixTestCase(Generic.Tests):
     name_singular = 'prefix'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='ipam/prefix.json')
     )
     def test_modify(self, *_):
@@ -117,11 +117,11 @@ class PrefixTestCase(Generic.Tests):
         self.assertEqual(ret_serialized['prefix'], '10.1.2.0/24')
 
     @patch(
-        'pynetbox.core.query.requests.put',
+        'pynetbox.core.query.requests.sessions.Session.put',
         return_value=Response(fixture='ipam/prefix.json')
     )
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='ipam/prefix.json')
     )
     def test_idempotence(self, *_):
@@ -130,7 +130,7 @@ class PrefixTestCase(Generic.Tests):
         self.assertFalse(test)
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         side_effect=[
             Response(fixture='ipam/prefix.json'),
             Response(fixture='ipam/available-ips.json'),
@@ -148,11 +148,11 @@ class PrefixTestCase(Generic.Tests):
         self.assertEqual(len(ret), 3)
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='ipam/available-ips-post.json')
     )
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='ipam/prefix.json'),
     )
     def test_create_available_ips(self, _, post):
@@ -183,7 +183,7 @@ class PrefixTestCase(Generic.Tests):
         self.assertEqual(ret, expected_result)
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         side_effect=[
             Response(fixture='ipam/prefix.json'),
             Response(fixture='ipam/available-prefixes.json'),
@@ -200,11 +200,11 @@ class PrefixTestCase(Generic.Tests):
         self.assertTrue(ret)
 
     @patch(
-        'pynetbox.core.query.requests.post',
+        'pynetbox.core.query.requests.sessions.Session.post',
         return_value=Response(fixture='ipam/available-prefixes-post.json')
     )
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='ipam/prefix.json'),
     )
     def test_create_available_prefixes(self, _, post):
@@ -227,7 +227,7 @@ class IPAddressTestCase(Generic.Tests):
     name_singular = 'ip_address'
 
     @patch(
-        'pynetbox.core.query.requests.get',
+        'pynetbox.core.query.requests.sessions.Session.get',
         return_value=Response(fixture='ipam/ip_address.json')
     )
     def test_modify(self, *_):

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -29,7 +29,7 @@ class Generic(object):
 
         def test_get_all(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -50,7 +50,7 @@ class Generic(object):
 
         def test_filter(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -71,7 +71,7 @@ class Generic(object):
 
         def test_get(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -29,7 +29,7 @@ class Generic(object):
 
         def test_get_all(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -50,7 +50,7 @@ class Generic(object):
 
         def test_filter(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name
@@ -71,7 +71,7 @@ class Generic(object):
 
         def test_get(self):
             with patch(
-                'pynetbox.core.query.requests.get',
+                'pynetbox.core.query.requests.sessions.Session.get',
                 return_value=Response(fixture='{}/{}.json'.format(
                     self.app,
                     self.name[:-1]


### PR DESCRIPTION
While using pynetbox for big amount of small changes in our netbox database I noticed an annoying latency. A colleague had a look to the network traffic and told me, that for every request a single http session gets initialized, used and closed.
This PR uses the onboard http sessions from requests. initialized in Api() and used by Request() and DetailEndpoint. It speeds up the communication by (re-)using a single http session per Api objects including keep-alive. The improvement is around 25%