### PR TITLE
Update endpoint.py

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -95,7 +95,7 @@ class Endpoint(object):
             ssl_verify=self.ssl_verify,
         )
         for i in req.get():
-          yield self._response_loader(i)
+            yield self._response_loader(i)
 
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -94,8 +94,8 @@ class Endpoint(object):
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
         )
-
-        return [self._response_loader(i) for i in req.get()]
+        for i in req.get():
+          yield self._response_loader(i)
 
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.


### PR DESCRIPTION
Convert Endpoint method "all" to generator. When you have many tenants - nb.tenancy.tenants.all() works very slow (for more than a second and more), while the generator is 3 times faster