### PR TITLE
Added the ability to send additional http headers

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -50,6 +50,7 @@ class App(object):
             token=self.api.token,
             private_key=self.api.private_key,
             ssl_verify=self.api.ssl_verify,
+            additional_headers=self.api.additional_headers,
         ).get()
 
         return self._choices
@@ -82,6 +83,7 @@ class Api(object):
     :param str,optional private_key: Your private key.
     :param bool/str,optional ssl_verify: Specify SSL verification behavior
         see: requests_.
+    :param dict,optional additional_headers: Additional headers
     :raises ValueError: If *private_key* and *private_key_file* are both
         specified.
     :raises AttributeError: If app doesn't exist.
@@ -105,6 +107,7 @@ class Api(object):
         private_key=None,
         private_key_file=None,
         ssl_verify=True,
+        additional_headers=None,
     ):
         if private_key and private_key_file:
             raise ValueError(
@@ -117,6 +120,7 @@ class Api(object):
         self.base_url = base_url
         self.ssl_verify = ssl_verify
         self.session_key = None
+        self.additional_headers = additional_headers
 
         if self.private_key_file:
             with open(self.private_key_file, "r") as kf:
@@ -128,6 +132,7 @@ class Api(object):
             token=token,
             private_key=private_key,
             ssl_verify=ssl_verify,
+            additional_headers=additional_headers,
         )
         if self.token and self.private_key:
             self.session_key = req.get_session_key()

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -47,6 +47,7 @@ class Endpoint(object):
         self.token = api.token
         self.session_key = api.session_key
         self.ssl_verify = api.ssl_verify
+        self.additional_headers = api.additional_headers
         self.url = "{base_url}/{app}/{endpoint}".format(
             base_url=self.base_url,
             app=app.name,
@@ -93,6 +94,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            additional_headers=self.additional_headers,
         )
 
         return [self._response_loader(i) for i in req.get()]
@@ -150,6 +152,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            additional_headers=self.additional_headers,
         )
 
         return self._response_loader(req.get())
@@ -215,6 +218,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            additional_headers=self.additional_headers,
         )
 
         ret = [self._response_loader(i) for i in req.get()]
@@ -276,6 +280,7 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             ssl_verify=self.ssl_verify,
+            additional_headers=self.additional_headers,
         ).post(args[0] if args else kwargs)
 
         if isinstance(req, list):
@@ -302,6 +307,7 @@ class DetailEndpoint(object):
             token=parent_obj.api.token,
             session_key=parent_obj.api.session_key,
             ssl_verify=parent_obj.api.ssl_verify,
+            additional_headers=parent_obj.api.additional_headers,
         )
 
     def list(self, **kwargs):

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -97,6 +97,7 @@ class Request(object):
         private_key=None,
         session_key=None,
         ssl_verify=True,
+        additional_headers=None,
     ):
         """
         Instantiates a new Request object
@@ -118,6 +119,7 @@ class Request(object):
         self.private_key = private_key
         self.session_key = session_key
         self.ssl_verify = ssl_verify
+        self.additional_headers = additional_headers
 
     def get_session_key(self):
         """Requests session key
@@ -127,13 +129,18 @@ class Request(object):
 
         :Returns: String containing session key.
         """
+        headers={
+            "accept": "application/json",
+            "authorization": "Token {}".format(self.token),
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        if self.additional_headers:
+            x = headers.copy()
+            x.update(self.additional_headers)
+            headers = x
         req = requests.post(
             "{}/secrets/get-session-key/?preserve_key=True".format(self.base),
-            headers={
-                "accept": "application/json",
-                "authorization": "Token {}".format(self.token),
-                "Content-Type": "application/x-www-form-urlencoded",
-            },
+            headers=headers,
             data=urlencode({"private_key": self.private_key.strip("\n")}),
             verify=self.ssl_verify,
         )
@@ -204,6 +211,10 @@ class Request(object):
             headers.update(authorization="Token {}".format(self.token))
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
+        if self.additional_headers:
+            x = headers.copy()
+            x.update(self.additional_headers)
+            headers = x
 
         def make_request(url):
 
@@ -255,6 +266,10 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
+        if self.additional_headers:
+            x = headers.copy()
+            x.update(self.additional_headers)
+            headers = x
         req = requests.put(
             self.url,
             headers=headers,
@@ -283,6 +298,10 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
+        if self.additional_headers:
+            x = headers.copy()
+            x.update(self.additional_headers)
+            headers = x
         req = requests.post(
             self.normalize_url(self.url),
             headers=headers,
@@ -309,6 +328,10 @@ class Request(object):
             "accept": "application/json;",
             "authorization": "Token {}".format(self.token),
         }
+        if self.additional_headers:
+            x = headers.copy()
+            x.update(self.additional_headers)
+            headers = x
         req = requests.delete(
             "{}".format(self.url), headers=headers, verify=self.ssl_verify
         )
@@ -333,6 +356,10 @@ class Request(object):
         }
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
+        if self.additional_headers:
+            x = headers.copy()
+            x.update(self.additional_headers)
+            headers = x
         req = requests.patch(
             self.url,
             headers=headers,

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -278,6 +278,7 @@ class Record(object):
                 token=self.api.token,
                 session_key=self.api.session_key,
                 ssl_verify=self.api.ssl_verify,
+                additional_headers=self.api.additional_headers,
             )
             self._parse_values(req.get())
             self.has_details = True
@@ -371,6 +372,7 @@ class Record(object):
                     token=self.api.token,
                     session_key=self.api.session_key,
                     ssl_verify=self.api.ssl_verify,
+                    additional_headers=self.api.additional_headers,
                 )
                 if req.patch({i: serialized[i] for i in diff}):
                     return True
@@ -419,5 +421,6 @@ class Record(object):
             token=self.api.token,
             session_key=self.api.session_key,
             ssl_verify=self.api.ssl_verify,
+            additional_headers=self.api.additional_headers,
         )
         return True if req.delete() else False


### PR DESCRIPTION
We use OIDC to authenticate and we have to replace Authentication header (Token vs Bearer).

Added the ability to send additional http headers to Netbox is a way more generic and acceptable.