### PR TITLE
Fix the App object not being picklable

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -32,7 +32,7 @@ class App(object):
         self.name = name
         self._choices = None
         self._setmodel()
-    
+
     models = {
         "dcim": dcim,
         "ipam": ipam,
@@ -50,7 +50,7 @@ class App(object):
             '_choices': self._choices
         }
 
-    def __setstate__(self,d):
+    def __setstate__(self, d):
         self.__dict__.update(d)
         self._setmodel()
 

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -33,13 +33,12 @@ class App(object):
         self._choices = None
         self._setmodel()
     
-		models = {
+    models = {
         "dcim": dcim,
         "ipam": ipam,
         "circuits": circuits,
         "virtualization": virtualization
     }
-
 
     def _setmodel(self):
         self.model = App.models[self.name] if self.name in App.models else None

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -27,12 +27,33 @@ class App(object):
     :raises: :py:class:`.RequestError`
         if requested endpoint doesn't exist.
     """
-
-    def __init__(self, api, name, model=None):
+    def __init__(self, api, name):
         self.api = api
         self.name = name
-        self.model = model
         self._choices = None
+        self._setmodel()
+    
+		models = {
+        "dcim": dcim,
+        "ipam": ipam,
+        "circuits": circuits,
+        "virtualization": virtualization
+    }
+
+
+    def _setmodel(self):
+        self.model = App.models[self.name] if self.name in App.models else None
+
+    def __getstate__(self):
+        return {
+            'api': self.api,
+            'name': self.name,
+            '_choices': self._choices
+        }
+
+    def __setstate__(self,d):
+        self.__dict__.update(d)
+        self._setmodel()
 
     def __getattr__(self, name):
         return Endpoint(self.api, self, name, model=self.model)
@@ -132,10 +153,10 @@ class Api(object):
         if self.token and self.private_key:
             self.session_key = req.get_session_key()
 
-        self.dcim = App(self, "dcim", model=dcim)
-        self.ipam = App(self, "ipam", model=ipam)
-        self.circuits = App(self, "circuits", model=circuits)
-        self.secrets = App(self, "secrets", model=None)
-        self.tenancy = App(self, "tenancy", model=None)
-        self.extras = App(self, "extras", model=None)
-        self.virtualization = App(self, "virtualization", model=virtualization)
+        self.dcim = App(self, "dcim")
+        self.ipam = App(self, "ipam")
+        self.circuits = App(self, "circuits")
+        self.secrets = App(self, "secrets")
+        self.tenancy = App(self, "tenancy")
+        self.extras = App(self, "extras")
+        self.virtualization = App(self, "virtualization")


### PR DESCRIPTION
Re: issue: Endpoint is not callable

https://github.com/digitalocean/pynetbox/issues/152

As the App object adds the model module as a property of the object, this object becomes unpicklable. Modules aren't picklable.

This PR adds the model dynamically based on its name during the init and again during the __setstate__.

Have tested it and now lists of devices are mapable. I don't think it breaks anything, but take a look.

Cheers,

Rob

