### PR TITLE
Add choices() in Endpoint using OPTIONS requests

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -289,7 +289,7 @@ class Endpoint(object):
 
         :Returns: Dict containing the available choices.
 
-        :Example:
+        :Examples:
 
         >>> from pprint import pprint
         >>> pprint(netbox.ipam.ip_addresses.choices())

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -52,6 +52,7 @@ class Endpoint(object):
             app=app.name,
             endpoint=name.replace("_", "-"),
         )
+        self._choices = None
 
     def _lookup_ret_obj(self, name, model):
         """Loads unique Response objects.
@@ -282,6 +283,46 @@ class Endpoint(object):
             return [self._response_loader(i) for i in req]
 
         return self._response_loader(req)
+
+    def choices(self):
+        """ Returns all choices from the endpoint.
+
+        :Returns: Dict containing the available choices.
+
+        :Example:
+
+        >>> from pprint import pprint
+        >>> pprint(netbox.ipam.ip_addresses.choices())
+        {'role': [{'display_name': 'Secondary', 'value': 20},
+                  {'display_name': 'VIP', 'value': 40},
+                  {'display_name': 'VRRP', 'value': 41},
+                  {'display_name': 'Loopback', 'value': 10},
+                  {'display_name': 'GLBP', 'value': 43},
+                  {'display_name': 'CARP', 'value': 44},
+                  {'display_name': 'HSRP', 'value': 42},
+                  {'display_name': 'Anycast', 'value': 30}],
+         'status': [{'display_name': 'Active', 'value': 1},
+                    {'display_name': 'Reserved', 'value': 2},
+                    {'display_name': 'Deprecated', 'value': 3},
+                    {'display_name': 'DHCP', 'value': 5}]}
+        >>>
+        """
+        if self._choices:
+            return self._choices
+
+        resp = Request(
+            base=self.url,
+            token=self.api.token,
+            private_key=self.api.private_key,
+            ssl_verify=self.api.ssl_verify,
+        ).options()
+        self._choices = {}
+        post_data = resp['actions']['POST']
+        for prop in post_data:
+            if 'choices' in post_data[prop]:
+                self._choices[prop] = post_data[prop]['choices']
+
+        return self._choices
 
 
 class DetailEndpoint(object):

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -310,14 +310,21 @@ class Endpoint(object):
         if self._choices:
             return self._choices
 
-        resp = Request(
+        req = Request(
             base=self.url,
             token=self.api.token,
             private_key=self.api.private_key,
             ssl_verify=self.api.ssl_verify,
         ).options()
+        try:
+            post_data = req['actions']['POST']
+        except KeyError:
+            raise ValueError(
+                "Unexpected format in the OPTIONS response at {}".format(
+                    self.url
+                )
+            )
         self._choices = {}
-        post_data = resp['actions']['POST']
         for prop in post_data:
             if 'choices' in post_data[prop]:
                 self._choices[prop] = post_data[prop]['choices']

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -409,3 +409,28 @@ class Request(object):
                 raise ContentError(req)
         else:
             raise RequestError(req)
+
+    def options(self):
+        """Makes an OPTIONS request.
+
+        Makes an OPTIONS request to NetBox's API.
+
+        :raises: RequestError if req.ok returns false.
+        :raises: ContentError if response is not json.
+
+        :returns: Dict containing the response from NetBox's API.
+        """
+        headers = {"accept": "application/json;"}
+        if self.token:
+            headers.update(authorization="Token {}".format(self.token))
+        if self.session_key:
+            headers.update({"X-Session-Key": self.session_key})
+
+        req = requests.options(self.url, headers=headers, verify=self.ssl_verify)
+        if req.ok:
+            try:
+                return req.json()
+            except json.JSONDecodeError:
+                raise ContentError(req)
+        else:
+            raise RequestError(req)

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -426,7 +426,11 @@ class Request(object):
         if self.session_key:
             headers.update({"X-Session-Key": self.session_key})
 
-        req = requests.options(self.url, headers=headers, verify=self.ssl_verify)
+        req = requests.options(
+            self.url,
+            headers=headers,
+            verify=self.ssl_verify,
+        )
         if req.ok:
             try:
                 return req.json()


### PR DESCRIPTION
As mentioned in #181, there is a discussion in NetBox (netbox-community/netbox#3416) to remove the _choices endpoints and use the Django-provided `OPTIONS` request.

This PR creates an options() method in Request class and a choices() method in Endpoint class, for using the `OPTIONS` interface. The existing App-level choices interface is still available for existing code to use it while supported by NetBox.

**Current choices style** (before this PR, with NetBox 2.6.6, lots of output omitted):

```
>>> from pprint import pprint
>>> pprint(netbox.ipam.choices())
...
 'ip-address:role': [{'label': 'Secondary', 'value': 20},
                     {'label': 'VIP', 'value': 40},
                     {'label': 'VRRP', 'value': 41},
                     {'label': 'Loopback', 'value': 10},
                     {'label': 'GLBP', 'value': 43},
                     {'label': 'CARP', 'value': 44},
                     {'label': 'HSRP', 'value': 42},
                     {'label': 'Anycast', 'value': 30}],
 'ip-address:status': [{'label': 'Active', 'value': 1},
                       {'label': 'Reserved', 'value': 2},
                       {'label': 'Deprecated', 'value': 3},
                       {'label': 'DHCP', 'value': 5}],
...
>>> pprint(netbox.dcim.choices())
...
 'device:face': [{'label': 'Front', 'value': 0}, {'label': 'Rear', 'value': 1}],
 'device:status': [{'label': 'Offline', 'value': 0},
                   {'label': 'Active', 'value': 1},
                   {'label': 'Planned', 'value': 2},
                   {'label': 'Staged', 'value': 3},
                   {'label': 'Failed', 'value': 4},
                   {'label': 'Inventory', 'value': 5},
                   {'label': 'Decommissioning', 'value': 6}],
...
 'site:status': [{'label': 'Active', 'value': 1},
                 {'label': 'Planned', 'value': 2},
                 {'label': 'Retired', 'value': 4}]}
...
```

**Examples with the new methods** (with NetBox 2.6.6):

```
>>> pprint(netbox.ipam.ip_addresses.choices())
{'role': [{'display_name': 'Secondary', 'value': 20},
          {'display_name': 'VIP', 'value': 40},
          {'display_name': 'VRRP', 'value': 41},
          {'display_name': 'Loopback', 'value': 10},
          {'display_name': 'GLBP', 'value': 43},
          {'display_name': 'CARP', 'value': 44},
          {'display_name': 'HSRP', 'value': 42},
          {'display_name': 'Anycast', 'value': 30}],
 'status': [{'display_name': 'Active', 'value': 1},
            {'display_name': 'Reserved', 'value': 2},
            {'display_name': 'Deprecated', 'value': 3},
            {'display_name': 'DHCP', 'value': 5}]}

>>> pprint(netbox.dcim.devices.choices())
{'face': [{'display_name': 'Front', 'value': 0},
          {'display_name': 'Rear', 'value': 1}],
 'status': [{'display_name': 'Offline', 'value': 0},
            {'display_name': 'Active', 'value': 1},
            {'display_name': 'Planned', 'value': 2},
            {'display_name': 'Staged', 'value': 3},
            {'display_name': 'Failed', 'value': 4},
            {'display_name': 'Inventory', 'value': 5},
            {'display_name': 'Decommissioning', 'value': 6}]}

>>> pprint(netbox.dcim.sites.choices())
{'status': [{'display_name': 'Active', 'value': 1},
            {'display_name': 'Planned', 'value': 2},
            {'display_name': 'Retired', 'value': 4}]}
```
