### PR TITLE
Add ContentError and AllocationError in documentation

### DIFF
--- a/docs/request.rst
+++ b/docs/request.rst
@@ -3,3 +3,9 @@ Request
 
 .. autoclass:: pynetbox.core.query.RequestError
   :members:
+
+.. autoclass:: pynetbox.core.query.ContentError
+  :members:
+
+.. autoclass:: pynetbox.core.query.AllocationError
+  :members:


### PR DESCRIPTION
Earlier ContentError and AllocationError were added in the code but not in the documentation, this fixes it.