### PR TITLE
data argument on DetailEndpoint.create() is mandatory

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -395,7 +395,7 @@ class DetailEndpoint(object):
             )
         return req
 
-    def create(self, data):
+    def create(self, data={}):
         """The write operation for a detail endpoint.
 
         Creates objects on a detail endpoint in NetBox.

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -395,7 +395,7 @@ class DetailEndpoint(object):
             )
         return req
 
-    def create(self, data={}):
+    def create(self, data=None):
         """The write operation for a detail endpoint.
 
         Creates objects on a detail endpoint in NetBox.
@@ -408,6 +408,8 @@ class DetailEndpoint(object):
         :returns: A dictionary or list of dictionaries its created in
             NetBox.
         """
+        if not data:
+            return Request(**self.request_kwargs).post({})
         return Request(**self.request_kwargs).post(data)
 
 


### PR DESCRIPTION
Reading the doc at https://pynetbox.readthedocs.io/en/latest/endpoint.html#pynetbox.core.endpoint.DetailEndpoint, the create() method is specified as having data, an optional argument.

Reading the code, the argument is mandatory and failing to specify it throws a TypeError.

```
In [26]: test = prefix.available_ips.create()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-26-ec77654da0ee> in <module>()
----> 1 test = prefix.available_ips.create()

TypeError: create() missing 1 required positional argument: 'data'

In [27]: test = prefix.available_ips.create({})

In [28]: test
Out[28]: 
{'id': 50507,
 'family': {'value': 4, 'label': 'IPv4'},
 'address': '172.29.68.59/22',
 'vrf': None,
 'tenant': None,
 'status': {'value': 1, 'label': 'Active'},
 'role': None,
 'interface': None,
 'description': '',
 'nat_inside': None,
 'nat_outside': None,
 'tags': [],
 'created': '2019-11-13',
 'last_updated': '2019-11-13T14:08:50.923183Z'}
```