### PR TITLE
Fixes #158: Adds count() method to Endpoint object.

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -341,6 +341,57 @@ class Endpoint(object):
 
         return self._choices
 
+    def count(self, *args, **kwargs):
+        r"""Returns the count of objects in a query.
+
+        Takes named arguments that match the usable filters on a
+        given endpoint. If an argument is passed then it's used as a
+        freeform search argument if the endpoint supports it. If no
+        arguments are passed the count for all objects on an endpoint
+        are returned.
+
+        :arg str,optional \*args: Freeform search string that's
+            accepted on given endpoint.
+        :arg str,optional \**kwargs: Any search argument the
+            endpoint accepts can be added as a keyword arg.
+
+        :Returns: Integer with count of objects returns by query.
+
+        :Examples:
+
+        To return a count of objects matching a named argument filter.
+
+        >>> nb.dcim.devices.count(site='tst1')
+        5827
+        >>>
+
+        To return a count of objects on an entire endpoint.
+
+        >>> nb.dcim.devices.count()
+        87382
+        >>>
+        """
+
+        if args:
+            kwargs.update({"q": args[0]})
+
+        if any(i in RESERVED_KWARGS for i in kwargs):
+            raise ValueError(
+                "A reserved {} kwarg was passed. Please remove it "
+                "try again.".format(RESERVED_KWARGS)
+            )
+
+        ret = Request(
+            filters=kwargs,
+            base=self.url,
+            token=self.token,
+            session_key=self.session_key,
+            ssl_verify=self.ssl_verify,
+            http_session=self.api.http_session,
+        )
+
+        return ret.get_count()
+
 
 class DetailEndpoint(object):
     """Enables read/write Operations on detail endpoints.

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -5,9 +5,9 @@ import six
 from pynetbox.core.endpoint import Endpoint
 
 if six.PY3:
-    from unittest.mock import patch, Mock
+    from unittest.mock import patch, Mock, call
 else:
-    from mock import patch, Mock
+    from mock import patch, Mock, call
 
 
 class EndPointTestCase(unittest.TestCase):
@@ -38,3 +38,42 @@ class EndPointTestCase(unittest.TestCase):
         test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
             test_obj.filter(id=1)
+
+    def test_count(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value={"count": 42}
+        ) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock()
+            app.name = "test-app"
+            expected_call = call('http://localhost:8000/api/test-app/test-endpoint/?test_filter=test&limit=1')
+            test_obj = Endpoint(api, app, "test_endpoint")
+            test = test_obj.count(test_filter="test")
+            self.assertEqual(test, 42)
+            self.assertEqual(mock.call_args, expected_call)
+
+    def test_count_args(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value={"count": 42}
+        ) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock()
+            app.name = "test-app"
+            expected_call = call('http://localhost:8000/api/test-app/test-endpoint/?q=test&limit=1')
+            test_obj = Endpoint(api, app, "test_endpoint")
+            test = test_obj.count("test")
+            self.assertEqual(test, 42)
+            self.assertEqual(mock.call_args, expected_call)
+
+    def test_count_no_args(self):
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value={"count": 42}
+        ) as mock:
+            api = Mock(base_url="http://localhost:8000/api")
+            app = Mock()
+            app.name = "test-app"
+            expected_call = call('http://localhost:8000/api/test-app/test-endpoint/?limit=1')
+            test_obj = Endpoint(api, app, "test_endpoint")
+            test = test_obj.count()
+            self.assertEqual(test, 42)
+            self.assertEqual(mock.call_args, expected_call)

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,0 +1,55 @@
+import unittest
+
+import six
+
+from pynetbox.core.query import Request
+
+if six.PY3:
+    from unittest.mock import patch, Mock, call
+else:
+    from mock import patch, Mock, call
+
+
+class RequestTestCase(unittest.TestCase):
+    def test_get_count(self):
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+            filters={"q": "abcd"},
+        )
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 42,
+            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1&q=abcd",
+            "previous": False,
+            "results": [],
+        }
+        expected = call(
+            "http://localhost:8001/api/dcim/devices/?q=abcd&limit=1",
+            headers={"accept": "application/json;"},
+            verify=True,
+        )
+        test_obj.http_session.get.ok = True
+        test = test_obj.get_count()
+        self.assertEqual(test, 42)
+        self.assertEqual(test_obj.http_session.get.call_args, expected)
+
+    def test_get_count_no_filters(self):
+        test_obj = Request(
+            http_session=Mock(),
+            base="http://localhost:8001/api/dcim/devices",
+        )
+        test_obj.http_session.get.return_value.json.return_value = {
+            "count": 42,
+            "next": "http://localhost:8001/api/dcim/devices?limit=1&offset=1",
+            "previous": False,
+            "results": [],
+        }
+        expected = call(
+            "http://localhost:8001/api/dcim/devices/?limit=1",
+            headers={"accept": "application/json;"},
+            verify=True,
+        )
+        test_obj.http_session.get.ok = True
+        test = test_obj.get_count()
+        self.assertEqual(test, 42)
+        self.assertEqual(test_obj.http_session.get.call_args, expected)


### PR DESCRIPTION
Returns the count for a given query by returning only the count field
after running the query with `limit=1`.