### PR TITLE
Fixes #141 - ChangeObject str return

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -17,7 +17,7 @@ import requests
 
 from pynetbox.core.endpoint import Endpoint
 from pynetbox.core.query import Request
-from pynetbox.models import dcim, ipam, virtualization, circuits
+from pynetbox.models import dcim, ipam, virtualization, circuits, extras
 
 
 class App(object):
@@ -39,7 +39,8 @@ class App(object):
         "dcim": dcim,
         "ipam": ipam,
         "circuits": circuits,
-        "virtualization": virtualization
+        "virtualization": virtualization,
+        "extras": extras
     }
 
     def _setmodel(self):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -18,7 +18,9 @@ from pynetbox.core.util import Hashabledict
 
 # List of fields that contain a dict but are not to be converted into
 # Record objects.
-JSON_FIELDS = ("custom_fields", "data", "config_context")
+JSON_FIELDS = (
+    "custom_fields", "data", "config_context", "object_data"
+)
 
 # List of fields that are lists but should be treated as sets.
 LIST_AS_SET = ("tags", "tagged_vlans")

--- a/pynetbox/models/extras.py
+++ b/pynetbox/models/extras.py
@@ -1,0 +1,21 @@
+"""
+(c) 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from pynetbox.core.response import Record
+
+
+class ObjectChanges(Record):
+    def __str__(self):
+        return self.request_id


### PR DESCRIPTION
Creates a custom model for ChangeObjects so their `__str__` can be set to
a field that exists on that model, request_id. Though not very human
friendly at the momement, I hope we can use `changed_object_type` to
load the proper model for objects in `changed_object` and we can use
their `__str__` methods instead.