### PR TITLE
Implements JsonField object

### DIFF
--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from pynetbox.core.response import Record
+from pynetbox.core.response import Record, JsonField
 from pynetbox.core.endpoint import RODetailEndpoint
 from pynetbox.models.ipam import IpAddresses
 from pynetbox.models.circuits import Circuits
@@ -44,6 +44,8 @@ class Devices(Record):
     primary_ip = IpAddresses
     primary_ip4 = IpAddresses
     primary_ip6 = IpAddresses
+    local_context_data = JsonField
+    config_context = JsonField
 
     @property
     def napalm(self):

--- a/pynetbox/models/extras.py
+++ b/pynetbox/models/extras.py
@@ -13,9 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from pynetbox.core.response import Record
+from pynetbox.core.response import Record, JsonField
+
+
+class ConfigContexts(Record):
+    data = JsonField
 
 
 class ObjectChanges(Record):
+    object_data = JsonField
+
     def __str__(self):
         return self.request_id

--- a/tests/fixtures/dcim/device.json
+++ b/tests/fixtures/dcim/device.json
@@ -65,6 +65,9 @@
     },
     "primary_ip6": null,
     "comments": "",
+    "local_context_data": {
+        "testing": "test"
+    },
     "custom_fields": {},
     "config_context": {
         "test_key": "test_val"

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -170,6 +170,7 @@ class DeviceTestCase(Generic.Tests):
         self.assertTrue(isinstance(ret.primary_ip4, pynetbox.models.ipam.IpAddresses))
         self.assertTrue(isinstance(ret.config_context, dict))
         self.assertTrue(isinstance(ret.custom_fields, dict))
+        self.assertTrue(isinstance(ret.local_context_data, dict))
         mock.assert_called_with(
             'http://localhost:8000/api/{}/{}/1/'.format(
                 self.app,


### PR DESCRIPTION
Is used on models to indicate that a dict should not be turns into a
Record object. Also implements `local_context_data` as such a field.