### PR TITLE
Add method to return custom choices

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -78,6 +78,24 @@ class App(object):
 
         return self._choices
 
+    def custom_choices(self):
+        """ Returns _custom_field_choices response from app
+
+        :Returns: Raw response from NetBox's _custom_field_choices endpoint.
+        :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
+        """
+        custom_field_choices = Request(
+            base="{}/{}/_custom_field_choices/".format(
+                self.api.base_url,
+                self.name,
+            ),
+            token=self.api.token,
+            private_key=self.api.private_key,
+            ssl_verify=self.api.ssl_verify,
+            http_session=self.api.http_session,
+        ).get()
+        return custom_field_choices
+
 
 class Api(object):
     """ The API object is the point of entry to pynetbox.

--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -83,6 +83,11 @@ class App(object):
 
         :Returns: Raw response from NetBox's _custom_field_choices endpoint.
         :Raises: :py:class:`.RequestError` if called for an invalid endpoint.
+        :Example:
+
+        >>> nb.extras.custom_choices()
+        {'Testfield1': {'Testvalue2': 2, 'Testvalue1': 1},
+         'Testfield2': {'Othervalue2': 4, 'Othervalue1': 3}}
         """
         custom_field_choices = Request(
             base="{}/{}/_custom_field_choices/".format(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+import unittest
+
+import six
+
+import pynetbox
+
+if six.PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
+
+host = "http://localhost:8000"
+
+def_kwargs = {
+    'token': 'abc123',
+}
+
+
+class AppCustomChoicesTestCase(unittest.TestCase):
+
+    @patch(
+        'pynetbox.core.query.Request.get',
+        return_value={
+            "Testfield1": {"TF1_1": 1, "TF1_2": 2},
+            "Testfield2": {"TF2_1": 3, "TF2_2": 4},
+        }
+    )
+    def test_custom_choices(self, *_):
+        api = pynetbox.api(
+            host,
+            **def_kwargs
+        )
+        choices = api.extras.custom_choices()
+        self.assertEqual(len(choices), 2)
+        self.assertEqual(sorted(choices.keys()), ["Testfield1", "Testfield2"])


### PR DESCRIPTION
This implements a method for `/_custom_field_choices` for `extras` app (#200). Example:

```
>>> nb.extras.custom_choices()
{'Testfield': {'Test2': 2, 'Test1': 1}, 'Testfield2': {'TF2': 4, 'TF1': 3}}
```

Some thoughts:

If called with other app than `extras`, the standard `RequestError` will be raised (because of 404 error):

```
>>> nb.dcim.custom_choices()
Traceback (most recent call last):
...
pynetbox.core.query.RequestError: The requested url: http://netbox.example.local/api/dcim/_custom_field_choices/ could not be found.
```
If desired, specific trigger for `NotImplementedError` can be implemented (`if self.name != "extras" ...`), I just felt keeping this simple after all.

No caching is done (`self._custom_field_choices` etc) because then editing the custom field choices in NetBox would require restarting the application using `pynetbox` (or handling the cache flush some other way).

Some unit test is still needed.