### PR TITLE
Skip params if url_override set in Request._make_call()

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -235,10 +235,11 @@ class Request(object):
             headers["X-Session-Key"] = self.session_key
 
         params = {}
-        if self.filters:
-            params = self.filters
-        if add_params:
-            params.update(add_params)
+        if not url_override:
+            if self.filters:
+                params = self.filters
+            if add_params:
+                params.update(add_params)
 
         req = getattr(self.http_session, verb)(
             url_override or self.url, headers=headers, verify=self.ssl_verify,


### PR DESCRIPTION
This seems to fix #206, but to be clear: this is a quick fix and I'm not sure at all if this causes some other problems somewhere, so if @zachmoody or someone else could check from some other viewpoint.