### PR TITLE
Issue #212 Accessing related resources via parent attribute uses corr…

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -282,8 +282,10 @@ class Record(object):
         model = app.model
 
         endpoint = self.endpoint.__class__(self.api, app, name, model)
+        related_obj = endpoint.return_obj(values, self.api, endpoint)
+        related_obj.has_details = False
 
-        return endpoint.return_obj(values, self.api, endpoint)
+        return related_obj
 
     def _compare(self):
         """Compares current attributes to values at instantiation.

--- a/pynetbox/models/virtualization.py
+++ b/pynetbox/models/virtualization.py
@@ -13,12 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from pynetbox.core.response import Record
+from pynetbox.core.response import Record, JsonField
 from pynetbox.models.ipam import IpAddresses
 
 
 class VirtualMachines(Record):
 
+    has_details = True
     primary_ip = IpAddresses
     primary_ip4 = IpAddresses
     primary_ip6 = IpAddresses
+    local_context_data = JsonField
+    config_context = JsonField


### PR DESCRIPTION
…ect models

Fix an issue whereby retrieving an object directly, e.g:
```
interface = client.dcim.interfaces.get(1)
```
and then accessing a related object from that object:
```
device = interface.device
```
would result in device being of a generic Record() type and the Endpoint
being that of the original interface object.  This is dangerous because:
```
device.delete()
```
would actually call delete against the interface and not the device.

This change, parses the url value of related objects to infer the App()
and record model that is appropriate to generate a new record of the
correct type with its proper endpoint.