### PR TITLE
Fixes Nested Record Write methods

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -140,6 +140,7 @@ class Request(object):
         private_key=None,
         session_key=None,
         ssl_verify=True,
+        url=None,
     ):
         """
         Instantiates a new Request object

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -384,8 +384,8 @@ class Record(object):
             if diff:
                 serialized = self.serialize()
                 req = Request(
-                    key=self.id,
-                    base=self.endpoint.url,
+                    key=self.id if not self.url else None,
+                    base=self.url or self.endpoint.url,
                     token=self.api.token,
                     session_key=self.api.session_key,
                     ssl_verify=self.api.ssl_verify,
@@ -433,8 +433,8 @@ class Record(object):
         >>>
         """
         req = Request(
-            key=self.id,
-            base=self.endpoint.url,
+            key=self.id if not self.url else None,
+            base=self.url or self.endpoint.url,
             token=self.api.token,
             session_key=self.api.session_key,
             ssl_verify=self.api.ssl_verify,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -139,3 +139,21 @@ class RecordTestCase(unittest.TestCase):
         test2 = Record({}, None, endpoint2)
         test2.id = 1
         self.assertEqual(test1, test2)
+
+    def test_nested_write(self):
+        app = Mock()
+        app.token = 'abc123'
+        endpoint = Mock()
+        endpoint.name = "test-endpoint"
+        test = Record({
+            'id': 123,
+            'name': 'test',
+            'child': {
+                'id': 321,
+                'name': 'test123',
+                'url': 'http://localhost:8080/test',
+            },
+        }, app, endpoint)
+        test.child.name = 'test321'
+        test.child.save()
+        self.assertEqual(app.http_session.patch.call_args[0][0], "http://localhost:8080/test/")


### PR DESCRIPTION
Previously if save() or delete() were called on nested records the URL called would be that of the parent. This fixes #161 and #212 by correcting that behavior.