### PR TITLE
Add deprecation note in App.choices()

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -65,6 +65,12 @@ class App(object):
     def choices(self):
         """ Returns _choices response from App
 
+        .. note::
+
+            This method is deprecated and only works with NetBox version 2.7.x
+            or older. The ``choices()`` method in :py:class:`.Endpoint` is
+            compatible with all NetBox versions.
+
         :Returns: Raw response from NetBox's _choices endpoint.
         """
         if self._choices:


### PR DESCRIPTION
NetBox 2.8.0 is out, and `App.choices()` does not work anymore. This PR adds a deprecation note in the method (and thus in the generated documentation as well), pointing the user to `Endpoint.choices()` instead. No changes in code.