### PR TITLE
Fixes #241: Inconsistent hashing for nested api objects

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -177,6 +177,7 @@ class Record(object):
                     r"(?P<app>\w*)/"
                     r"(?P<endpoint>\w*)/"
                     r"(?P<key>\w*)/"
+                    r"(\?(.*=.*&?)+)?"
                     r"(?!\w)$"
                 )
                 url_match = url_re.match(values['url'])

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -96,7 +96,6 @@ class VirtualChassis(Record):
 
 
 class RUs(Record):
-
     device = Devices
 
 
@@ -124,7 +123,8 @@ class Racks(Record):
         """ Represents the ``elevation`` detail endpoint.
 
         Returns a DetailEndpoint object that is the interface for
-        viewing response from the elevation endpoint updated in Netbox version 2.8.
+        viewing response from the elevation endpoint updated in
+        Netbox version 2.8.
 
         :returns: :py:class:`.DetailEndpoint`
 
@@ -136,6 +136,7 @@ class Racks(Record):
 
         """
         return RODetailEndpoint(self, "elevation", custom_return=RUs)
+
 
 class Termination(Record):
     def __str__(self):

--- a/tests/fixtures/dcim/interface.json
+++ b/tests/fixtures/dcim/interface.json
@@ -42,5 +42,26 @@
         "id": 1,
         "url": "http://localhost:8000/api/dcim/cables/1/",
         "label": ""
-    }
+    },
+    "mode": {
+        "value": "tagged",
+        "label": "Tagged",
+        "id": 200
+    },
+    "untagged_vlan": {
+        "id": 2,
+        "url": "http://localhost:8000/api/ipam/vlans/792/",
+        "vid": 2069,
+        "name": "v2069",
+        "display_name": "2069 (v2069)"
+    },
+    "tagged_vlans": [
+        {
+            "id": 3,
+            "url": "http://localhost:8000/api/ipam/vlans/248/",
+            "vid": 1210,
+            "name": "v1210",
+            "display_name": "1210 (v1210)"
+        }
+    ]
 }

--- a/tests/fixtures/ipam/vlan.json
+++ b/tests/fixtures/ipam/vlan.json
@@ -1,5 +1,5 @@
 {
-    "id": 1,
+    "id": 3,
     "site": {
         "id": 1,
         "url": "http://localhost:8000/api/dcim/sites/1/",
@@ -7,8 +7,8 @@
         "slug": "test1"
     },
     "group": null,
-    "vid": 999,
-    "name": "TEST",
+    "vid": 1210,
+    "name": "v1210",
     "tenant": null,
     "status": {
         "value": 1,
@@ -21,6 +21,6 @@
         "slug": "lab-network"
     },
     "description": "",
-    "display_name": "999 (TEST)",
+    "display_name": "1210 (v1210)",
     "custom_fields": {}
 }

--- a/tests/fixtures/ipam/vlans.json
+++ b/tests/fixtures/ipam/vlans.json
@@ -1,5 +1,5 @@
 {
-    "count": 1,
+    "count": 3,
     "next": null,
     "previous": null,
     "results": [
@@ -27,6 +27,58 @@
             },
             "description": "",
             "display_name": "999 (TEST)",
+            "custom_fields": {}
+        },
+        {
+            "id": 2,
+            "site": {
+                "id": 1,
+                "url": "http://localhost:8000/api/dcim/sites/1/",
+                "name": "TEST1",
+                "slug": "test1"
+            },
+            "group": null,
+            "vid": 2069,
+            "name": "v2069",
+            "tenant": null,
+            "status": {
+                "value": 1,
+                "label": "Active"
+            },
+            "role": {
+                "id": 1,
+                "url": "http://localhost:8000/api/ipam/roles/1/",
+                "name": "Lab Network",
+                "slug": "lab-network"
+            },
+            "description": "",
+            "display_name": "2069 (v2069)",
+            "custom_fields": {}
+        },
+        {
+            "id": 3,
+            "site": {
+                "id": 1,
+                "url": "http://localhost:8000/api/dcim/sites/1/",
+                "name": "TEST1",
+                "slug": "test1"
+            },
+            "group": null,
+            "vid": 1210,
+            "name": "v1210",
+            "tenant": null,
+            "status": {
+                "value": 1,
+                "label": "Active"
+            },
+            "role": {
+                "id": 1,
+                "url": "http://localhost:8000/api/ipam/roles/1/",
+                "name": "Lab Network",
+                "slug": "lab-network"
+            },
+            "description": "",
+            "display_name": "1210 (v1210)",
             "custom_fields": {}
         }
     ]

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -269,6 +269,27 @@ class AggregatesTestCase(Generic.Tests):
 class VlanTestCase(Generic.Tests):
     name = 'vlans'
 
+    @patch(
+        'pynetbox.core.query.requests.sessions.Session.get',
+        side_effect=[
+            Response(fixture='ipam/vlan.json'),
+            Response(fixture='dcim/interface.json'),
+        ]
+    )
+    def test_vlan_in_interface(self, mock):
+        vlan = nb.vlans.get(3)
+        interface = api.dcim.interfaces.get(1)
+        mock.assert_called_with(
+            'http://localhost:8000/api/dcim/interfaces/1/',
+            params={},
+            json=None,
+            headers=HEADERS,
+            verify=True
+        )
+        self.assertEqual(vlan.vid, interface.tagged_vlans[0].vid)
+        self.assertEqual(vlan.id, interface.tagged_vlans[0].id)
+        self.assertTrue(vlan in interface.tagged_vlans)
+
 
 class VlanGroupsTestCase(Generic.Tests):
     name = 'vlan_groups'


### PR DESCRIPTION
### Fixes #241

As proposed here: https://github.com/digitalocean/pynetbox/issues/241#issuecomment-643430226 I went with option 1.

Let me know if you see a different fix for this.