### PR TITLE
sort lists for correct comparison later

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -346,6 +346,7 @@ class Record(object):
                     ]
                     if i in LIST_AS_SET:
                         current_val = list(set(current_val))
+                    current_val.sort()
                 ret[i] = current_val
         return ret
 


### PR DESCRIPTION
I sometimes noticed objects (like devices) are reporting True on .save(), but there where actually no changes.
I found out that the tags list of the initial and changed object sometimes don't have the same ordering, which is fixed by this PR.

I thought of adding a test like this to `tests/unit/test_response.py`:
```python
def test_serialize_tag_list(self):
    test_values1 = {"id": 123, "tags": ["foo", "bar"]}
    test1 = Record(test_values1, None, None).serialize()
    test_values2 = {"id": 123, "tags": ["bar", "foo"]}
    test2 = Record(test_values2, None, None).serialize()
    self.assertEqual(test1, test2)
```
But as this test will only fail sometimes, I think it makes no sense to add this test.
But maybe you have a better idea.