### PR TITLE
Move population of api.session_key to App

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -97,16 +97,6 @@ class Api(object):
                 private_key = kf.read()
                 self.private_key = private_key
 
-        req = Request(
-            base=base_url,
-            token=token,
-            private_key=private_key,
-            ssl_verify=ssl_verify,
-            http_session=self.http_session
-        )
-        if self.token and self.private_key:
-            self.session_key = req.get_session_key()
-
         self.dcim = App(self, "dcim")
         self.ipam = App(self, "ipam")
         self.circuits = App(self, "circuits")

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -56,7 +56,21 @@ class App(object):
         self._setmodel()
 
     def __getattr__(self, name):
+        if name == "secrets":
+            self._set_session_key()
         return Endpoint(self.api, self, name, model=self.model)
+
+    def _set_session_key(self):
+        if getattr(self.api, "session_key"):
+            return
+        if self.api.token and self.api.private_key:
+            self.api.session_key = Request(
+                base=self.api.base_url,
+                token=self.api.token,
+                private_key=self.api.private_key,
+                ssl_verify=self.api.ssl_verify,
+                http_session=self.api.http_session
+            ).get_session_key()
 
     def choices(self):
         """ Returns _choices response from App


### PR DESCRIPTION
In order to set a custom http_session for use universally we need to move any
requests out of Api's init. Moving it to App and only calling it when we
need App.secrets.