### PR TITLE
Remove ssl_verify init kwarg

### DIFF
--- a/pynetbox/api.py
+++ b/pynetbox/api.py
@@ -39,15 +39,12 @@ class Api(object):
     Calling any of these attributes will return
     :py:class:`.App` which exposes endpoints as attributes.
 
-    :type ssl_verify: bool or str
     :param str url: The base URL to the instance of NetBox you
         wish to connect to.
     :param str token: Your NetBox token.
     :param str,optional private_key_file: The path to your private
         key file.
     :param str,optional private_key: Your private key.
-    :param bool/str,optional ssl_verify: Specify SSL verification behavior
-        see: requests_.
     :param bool,optional threading: Set to True to use threading in ``.all()``
         and ``.filter()`` requests.
     :raises ValueError: If *private_key* and *private_key_file* are both
@@ -62,9 +59,7 @@ class Api(object):
     ...     token='d6f4e314a5b5fefd164995169f28ae32d987704f'
     ... )
     >>> nb.dcim.devices.all()
-
-    .. _requests: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
-    """  # noqa
+    """
 
     def __init__(
         self,
@@ -72,7 +67,6 @@ class Api(object):
         token=None,
         private_key=None,
         private_key_file=None,
-        ssl_verify=True,
         threading=False,
     ):
         if private_key and private_key_file:
@@ -84,7 +78,6 @@ class Api(object):
         self.private_key = private_key
         self.private_key_file = private_key_file
         self.base_url = base_url
-        self.ssl_verify = ssl_verify
         self.session_key = None
         self.http_session = requests.Session()
         if threading and sys.version_info.major == 2:
@@ -127,7 +120,6 @@ class Api(object):
         """
         version = Request(
             base=self.base_url,
-            ssl_verify=self.ssl_verify,
             http_session=self.http_session,
         ).get_version()
         return version
@@ -152,6 +144,5 @@ class Api(object):
         """
         return Request(
             base=self.base_url,
-            ssl_verify=self.ssl_verify,
             http_session=self.http_session,
         ).get_openapi()

--- a/pynetbox/core/app.py
+++ b/pynetbox/core/app.py
@@ -68,7 +68,6 @@ class App(object):
                 base=self.api.base_url,
                 token=self.api.token,
                 private_key=self.api.private_key,
-                ssl_verify=self.api.ssl_verify,
                 http_session=self.api.http_session
             ).get_session_key()
 
@@ -90,7 +89,6 @@ class App(object):
             base="{}/{}/_choices/".format(self.api.base_url, self.name),
             token=self.api.token,
             private_key=self.api.private_key,
-            ssl_verify=self.api.ssl_verify,
             http_session=self.api.http_session,
         ).get()
 
@@ -114,7 +112,6 @@ class App(object):
             ),
             token=self.api.token,
             private_key=self.api.private_key,
-            ssl_verify=self.api.ssl_verify,
             http_session=self.api.http_session,
         ).get()
         return custom_field_choices

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -47,7 +47,6 @@ class Endpoint(object):
         self.base_url = api.base_url
         self.token = api.token
         self.session_key = api.session_key
-        self.ssl_verify = api.ssl_verify
         self.url = "{base_url}/{app}/{endpoint}".format(
             base_url=self.base_url,
             app=app.name,
@@ -94,7 +93,6 @@ class Endpoint(object):
             base="{}/".format(self.url),
             token=self.token,
             session_key=self.session_key,
-            ssl_verify=self.ssl_verify,
             http_session=self.api.http_session,
             threading=self.api.threading,
         )
@@ -154,7 +152,6 @@ class Endpoint(object):
                 base=self.url,
                 token=self.token,
                 session_key=self.session_key,
-                ssl_verify=self.ssl_verify,
                 http_session=self.api.http_session,
             )
         except RequestError:
@@ -222,7 +219,6 @@ class Endpoint(object):
             base=self.url,
             token=self.token,
             session_key=self.session_key,
-            ssl_verify=self.ssl_verify,
             http_session=self.api.http_session,
             threading=self.api.threading,
         )
@@ -285,7 +281,6 @@ class Endpoint(object):
             base=self.url,
             token=self.token,
             session_key=self.session_key,
-            ssl_verify=self.ssl_verify,
             http_session=self.api.http_session,
         ).post(args[0] if args else kwargs)
 
@@ -330,7 +325,6 @@ class Endpoint(object):
             base=self.url,
             token=self.api.token,
             private_key=self.api.private_key,
-            ssl_verify=self.api.ssl_verify,
             http_session=self.api.http_session,
         ).options()
         try:
@@ -393,7 +387,6 @@ class Endpoint(object):
             base=self.url,
             token=self.token,
             session_key=self.session_key,
-            ssl_verify=self.ssl_verify,
             http_session=self.api.http_session,
         )
 
@@ -417,7 +410,6 @@ class DetailEndpoint(object):
             base=self.url,
             token=parent_obj.api.token,
             session_key=parent_obj.api.session_key,
-            ssl_verify=parent_obj.api.ssl_verify,
             http_session=parent_obj.api.http_session,
         )
 

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -148,7 +148,6 @@ class Request(object):
         token=None,
         private_key=None,
         session_key=None,
-        ssl_verify=True,
         threading=False,
     ):
         """
@@ -170,7 +169,6 @@ class Request(object):
         self.token = token
         self.private_key = private_key
         self.session_key = session_key
-        self.ssl_verify = ssl_verify
         self.http_session = http_session
         self.url = self.base if not key else "{}{}/".format(self.base, key)
         self.threading = threading
@@ -183,7 +181,6 @@ class Request(object):
         req = self.http_session.get(
             "{}docs/?format=openapi".format(self.normalize_url(self.base)),
             headers=headers,
-            verify=self.ssl_verify,
         )
         if req.ok:
             return req.json()
@@ -206,7 +203,6 @@ class Request(object):
         req = requests.get(
             self.normalize_url(self.base),
             headers=headers,
-            verify=self.ssl_verify,
         )
         if req.ok:
             return req.headers.get("API-Version", "")
@@ -229,7 +225,6 @@ class Request(object):
                 "Content-Type": "application/x-www-form-urlencoded",
             },
             data=urlencode({"private_key": self.private_key.strip("\n")}),
-            verify=self.ssl_verify,
         )
         if req.ok:
             try:
@@ -268,7 +263,7 @@ class Request(object):
                 params.update(add_params)
 
         req = getattr(self.http_session, verb)(
-            url_override or self.url, headers=headers, verify=self.ssl_verify,
+            url_override or self.url, headers=headers,
             params=params, json=data
         )
 

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -306,7 +306,6 @@ class Record(object):
                 base=self.url,
                 token=self.api.token,
                 session_key=self.api.session_key,
-                ssl_verify=self.api.ssl_verify,
                 http_session=self.api.http_session,
             )
             self._parse_values(req.get())
@@ -400,7 +399,6 @@ class Record(object):
                     base=self.endpoint.url,
                     token=self.api.token,
                     session_key=self.api.session_key,
-                    ssl_verify=self.api.ssl_verify,
                     http_session=self.api.http_session,
                 )
                 if req.patch({i: serialized[i] for i in diff}):
@@ -449,7 +447,6 @@ class Record(object):
             base=self.endpoint.url,
             token=self.api.token,
             session_key=self.api.session_key,
-            ssl_verify=self.api.ssl_verify,
             http_session=self.api.http_session,
         )
         return True if req.delete() else False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -53,42 +53,6 @@ class ApiTestCase(unittest.TestCase):
         self.assertEqual(api.base_url, 'http://localhost:8000/api')
 
 
-class ApiArgumentsTestCase(unittest.TestCase):
-
-    @patch(
-        'pynetbox.core.query.requests.sessions.Session.post',
-        return_value=Response(fixture='api/get_session_key.json')
-    )
-    def common_arguments(self, kwargs, arg, expect, *_):
-        '''
-        Ensures the api and endpoint instances have ssl_verify set
-        as expected
-        '''
-        api = pynetbox.api(
-            host,
-            **kwargs
-        )
-        self.assertIs(getattr(api, arg, "fail"), expect)
-        for app, endpoint in endpoints.items():
-            ep = getattr(getattr(api, app), endpoint)
-            self.assertIs(getattr(ep, arg), expect)
-
-    def test_ssl_verify_default(self):
-        self.common_arguments(def_kwargs, 'ssl_verify', True)
-
-    def test_ssl_verify_true(self):
-        kwargs = dict(def_kwargs, **{'ssl_verify': True})
-        self.common_arguments(kwargs, 'ssl_verify', True)
-
-    def test_ssl_verify_false(self):
-        kwargs = dict(def_kwargs, **{'ssl_verify': False})
-        self.common_arguments(kwargs, 'ssl_verify', False)
-
-    def test_ssl_verify_string(self):
-        kwargs = dict(def_kwargs, **{'ssl_verify': '/path/to/bundle'})
-        self.common_arguments(kwargs, 'ssl_verify', '/path/to/bundle')
-
-
 class ApiVersionTestCase(unittest.TestCase):
 
     class ResponseHeadersWithVersion:

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -46,7 +46,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_filter(self):
@@ -69,7 +68,6 @@ class Generic(object):
                     params={"name": "test"},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_get(self):
@@ -91,7 +89,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
 

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -49,7 +49,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_filter(self):
@@ -72,7 +71,6 @@ class Generic(object):
                     params={"name": "test"},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_get(self):
@@ -96,7 +94,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_delete(self):
@@ -117,7 +114,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
                 delete.assert_called_with(
                     'http://localhost:8000/api/{}/{}/1/'.format(
@@ -127,7 +123,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_compare(self):
@@ -179,7 +174,6 @@ class DeviceTestCase(Generic.Tests):
             params={},
             json=None,
             headers=HEADERS,
-            verify=True
         )
 
     @patch(
@@ -199,7 +193,6 @@ class DeviceTestCase(Generic.Tests):
             params={'role': ['test', 'test1'], 'site': 'TEST#1'},
             json=None,
             headers=HEADERS,
-            verify=True
         )
 
     @patch(
@@ -285,7 +278,6 @@ class DeviceTestCase(Generic.Tests):
             params={"method": "get_facts"},
             json=None,
             headers=HEADERS,
-            verify=True,
         )
         self.assertTrue(ret)
         self.assertTrue(ret['get_facts'])
@@ -372,7 +364,6 @@ class InterfaceTestCase(Generic.Tests):
             params={"limit": 221, "offset": 50},
             json=None,
             headers=HEADERS,
-            verify=True
         )
 
 
@@ -394,7 +385,6 @@ class RackTestCase(Generic.Tests):
             params={},
             json=None,
             headers=HEADERS,
-            verify=True,
         )
         self.assertTrue(ret)
         self.assertTrue(
@@ -416,7 +406,6 @@ class RackTestCase(Generic.Tests):
             params={},
             json=None,
             headers=HEADERS,
-            verify=True,
         )
         self.assertTrue(ret)
         self.assertTrue(
@@ -533,7 +522,6 @@ class Choices(unittest.TestCase):
                 params={},
                 json=None,
                 headers=HEADERS,
-                verify=True
             )
 
 
@@ -596,5 +584,4 @@ class CablesTestCase(Generic.Tests):
                 headers=HEADERS,
                 params={},
                 json=None,
-                verify=True
             )

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -57,7 +57,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_filter(self):
@@ -80,7 +79,6 @@ class Generic(object):
                     params={"name": "test"},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_get(self):
@@ -104,7 +102,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
 
@@ -152,7 +149,6 @@ class PrefixTestCase(Generic.Tests):
             params={},
             json=None,
             headers=HEADERS,
-            verify=True
         )
         self.assertTrue(ret)
         self.assertEqual(len(ret), 3)
@@ -188,7 +184,6 @@ class PrefixTestCase(Generic.Tests):
             params={},
             headers=POST_HEADERS,
             json=create_parms,
-            verify=True
         )
         self.assertTrue(ret)
         self.assertEqual(ret, expected_result)
@@ -208,7 +203,6 @@ class PrefixTestCase(Generic.Tests):
             params={},
             json=None,
             headers=HEADERS,
-            verify=True
         )
         self.assertTrue(ret)
 
@@ -231,7 +225,6 @@ class PrefixTestCase(Generic.Tests):
             params={},
             headers=POST_HEADERS,
             json=create_parms,
-            verify=True
         )
         self.assertTrue(ret)
 
@@ -284,7 +277,6 @@ class VlanTestCase(Generic.Tests):
             params={},
             json=None,
             headers=HEADERS,
-            verify=True
         )
         self.assertEqual(vlan.vid, interface.tagged_vlans[0].vid)
         self.assertEqual(vlan.id, interface.tagged_vlans[0].id)

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -47,7 +47,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_filter(self):
@@ -70,7 +69,6 @@ class Generic(object):
                     params={"name": "test"},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_get(self):
@@ -92,7 +90,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
 

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -47,7 +47,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_filter(self):
@@ -70,7 +69,6 @@ class Generic(object):
                     params={"name": "test"},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
         def test_get(self):
@@ -92,7 +90,6 @@ class Generic(object):
                     params={},
                     json=None,
                     headers=HEADERS,
-                    verify=True
                 )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -27,7 +27,6 @@ class RequestTestCase(unittest.TestCase):
             "http://localhost:8001/api/dcim/devices/",
             params={"q": "abcd", "limit": 1},
             headers={"accept": "application/json;"},
-            verify=True,
         )
         test_obj.http_session.get.ok = True
         test = test_obj.get_count()
@@ -37,7 +36,6 @@ class RequestTestCase(unittest.TestCase):
             params={"q": "abcd", "limit": 1},
             headers={"accept": "application/json;"},
             json=None,
-            verify=True,
         )
 
     def test_get_count_no_filters(self):
@@ -59,5 +57,4 @@ class RequestTestCase(unittest.TestCase):
             params={"limit": 1},
             headers={"accept": "application/json;"},
             json=None,
-            verify=True,
         )

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -18,5 +18,4 @@ class RequestTestCase(unittest.TestCase):
         test.http_session.get.assert_called_with(
             "http://localhost:8080/api/docs/?format=openapi",
             headers={'Content-Type': 'application/json;'},
-            verify=True,
         )


### PR DESCRIPTION
With the ability to set api.http_session to a custom Session we can
handle SSL verification with it instead of an explicit kwarg.