### PR TITLE
Fixes #260: Change Request.get_version() to use self.http_session

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -197,10 +197,7 @@ class Request(object):
         headers = {
             "Content-Type": "application/json;",
         }
-        req = self.http_session.get(
-            self.normalize_url(self.base),
-            headers=headers,
-        )
+        req = self.http_session.get(self.normalize_url(self.base), headers=headers,)
         if req.ok:
             return req.headers.get("API-Version", "")
         else:

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -197,7 +197,10 @@ class Request(object):
         headers = {
             "Content-Type": "application/json;",
         }
-        req = requests.get(self.normalize_url(self.base), headers=headers,)
+        req = self.http_session.get(
+            self.normalize_url(self.base),
+            headers=headers,
+        )
         if req.ok:
             return req.headers.get("API-Version", "")
         else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,7 +51,10 @@ class ApiVersionTestCase(unittest.TestCase):
         headers = {"API-Version": "1.999"}
         ok = True
 
-    @patch("requests.get", return_value=ResponseHeadersWithVersion())
+    @patch(
+        "pynetbox.core.query.requests.sessions.Session.get",
+        return_value=ResponseHeadersWithVersion(),
+    )
     def test_api_version(self, *_):
         api = pynetbox.api(host,)
         self.assertEqual(api.version, "1.999")
@@ -60,7 +63,10 @@ class ApiVersionTestCase(unittest.TestCase):
         headers = {}
         ok = True
 
-    @patch("requests.get", return_value=ResponseHeadersWithoutVersion())
+    @patch(
+        "pynetbox.core.query.requests.sessions.Session.get",
+        return_value=ResponseHeadersWithoutVersion(),
+    )
     def test_api_version_not_found(self, *_):
         api = pynetbox.api(host,)
         self.assertEqual(api.version, "")


### PR DESCRIPTION
There was a leftover `requests.get()` so I replaced it with `self.http_session.get()`. This makes netbox.version work for me:

```
>>> import pynetbox
>>> import requests
>>> netbox = pynetbox.api("https://my-internal-netbox.example.com",token="7638a7d4a49b56d2f1449aca95c14c51ad37f072")
>>> s = requests.Session()
>>> s.verify = "/usr/local/share/ca-certificates/my-own-ca.crt"
>>> netbox.http_session = s
>>> netbox.version
'2.8'
>>>
```