### PR TITLE
Fixes #262: Missing or duplicated results for .filter() when threading is enabled

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -250,7 +250,7 @@ class Request(object):
         params = {}
         if not url_override:
             if self.filters:
-                params = self.filters
+                params.update(self.filters)
             if add_params:
                 params.update(add_params)
 


### PR DESCRIPTION
As mentioned in #262, we sometimes see missing or duplicated results when calling nb.dcim.devices.filter() with threading enabled.
Troubleshooting showed that the requests themselves are scheduled with correct offsets, though when the actual calls happen, params seem to be overwritten, further causing incorrect results. Not always, but often enough, and especially visible with low MAX_PAGE_SIZE values.
![image](https://user-images.githubusercontent.com/46579601/86532534-7d6e9f00-bed3-11ea-8e9c-3dde81e100c2.png)

In the implementation of query.py, I've noticed that concurrent sessions seem to use the same copy of the attrubute "self.filters" (that params = self.filters). That's why params.update(add_params) would sometimes cause collisions depending on the time when a particular request is called.
```python
        params = {}
         if not url_override:
             if self.filters:
                 params = self.filters
             if add_params:
                 params.update(add_params)
```
An example of this dict:
```python
{'role': ['switch', 'router'], 'has_primary_ip': True, 'limit': 20, 'offset': 60}
```
I think changing it to: 
```python
        params = {}
        if not url_override:
            if self.filters:
                params.update(self.filters)
            if add_params:
                params.update(add_params)
```
will help to mitigate the issue. At least, in my tests it seems to work.

UPD: a bit rewritten my text to make it clearer.