### PR TITLE
Fix tag ordering

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import copy
+from collections import OrderedDict
 
 import pynetbox.core.app
 from six.moves.urllib.parse import urlsplit
@@ -341,7 +342,7 @@ class Record(object):
                         v.id if isinstance(v, Record) else v for v in current_val
                     ]
                     if i in LIST_AS_SET:
-                        current_val = list(set(current_val))
+                        current_val = list(OrderedDict.fromkeys(current_val))
                 ret[i] = current_val
         return ret
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -211,6 +211,12 @@ class RecordTestCase(unittest.TestCase):
         self.assertEqual(ret.name, "test-endpoint")
 
     def test_serialize_tag_list_order(self):
+        """Add tests to ensure we're preserving tag order
+
+        This test could still give false-negatives, but making the tag list
+        longer helps mitigate that.
+        """
+
         test_tags = [
             "one",
             "two",

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -209,3 +209,19 @@ class RecordTestCase(unittest.TestCase):
         )
         ret = test._endpoint_from_url(test.url)
         self.assertEqual(ret.name, "test-endpoint")
+
+    def test_serialize_tag_list_order(self):
+        test_tags = [
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+        ]
+        test = Record({"id": 123, "tags": test_tags}, None, None).serialize()
+        self.assertEqual(test["tags"], test_tags)


### PR DESCRIPTION
Fixes issue with tag order sometimes being modified in serialize() when we cast to set(). Which caused save() to make unnecessary calls to NetBox.