### PR TITLE
Allow iteration for result from Endpoints

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -75,7 +75,7 @@ class Endpoint(object):
     def _response_loader(self, values):
         return self.return_obj(values, self.api, self)
 
-    def iall(self):
+    def iterall(self):
         """Queries the 'ListView' of a given endpoint.
 
         Returns all objects from an endpoint.
@@ -100,7 +100,7 @@ class Endpoint(object):
 
     def all(self):
         """ consumes the above generator and return list of records """
-        return list(self.iall())
+        return list(self.iterall())
 
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.
@@ -159,7 +159,7 @@ class Endpoint(object):
 
         return self._response_loader(req.get())
 
-    def ifilter(self, *args, **kwargs):
+    def iterfilter(self, *args, **kwargs):
         r"""Queries the 'ListView' of a given endpoint.
 
         Takes named arguments that match the usable filters on a
@@ -226,7 +226,7 @@ class Endpoint(object):
             yield self._response_loader(i)
 
     def filter(self, *args, **kwargs):
-        return list(self.ifilter(*args, **kwargs))
+        return list(self.iterfilter(*args, **kwargs))
 
     def create(self, *args, **kwargs):
         r"""Creates an object on an endpoint.

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -75,7 +75,7 @@ class Endpoint(object):
     def _response_loader(self, values):
         return self.return_obj(values, self.api, self)
 
-    def all(self):
+    def iall(self):
         """Queries the 'ListView' of a given endpoint.
 
         Returns all objects from an endpoint.
@@ -95,7 +95,12 @@ class Endpoint(object):
             ssl_verify=self.ssl_verify,
         )
 
-        return [self._response_loader(i) for i in req.get()]
+        for i in req.get():
+            yield self._response_loader(i)
+
+    def all(self):
+        """ consumes the above generator and return list of records """
+        return list(self.iall())
 
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.
@@ -154,7 +159,7 @@ class Endpoint(object):
 
         return self._response_loader(req.get())
 
-    def filter(self, *args, **kwargs):
+    def ifilter(self, *args, **kwargs):
         r"""Queries the 'ListView' of a given endpoint.
 
         Takes named arguments that match the usable filters on a
@@ -217,8 +222,11 @@ class Endpoint(object):
             ssl_verify=self.ssl_verify,
         )
 
-        ret = [self._response_loader(i) for i in req.get()]
-        return ret
+        for i in req.get():
+            yield self._response_loader(i)
+
+    def filter(self, *args, **kwargs):
+        return list(self.ifilter(*args, **kwargs))
 
     def create(self, *args, **kwargs):
         r"""Creates an object on an endpoint.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.20.0,<3.0
 six==1.*
+mock

--- a/tests/fixtures/circuits/providers.json
+++ b/tests/fixtures/circuits/providers.json
@@ -1,5 +1,5 @@
 {
-    "count": 1,
+    "count": 2,
     "next": null,
     "previous": null,
     "results": [
@@ -7,6 +7,18 @@
             "id": 1,
             "name": "TEST",
             "slug": "test",
+            "asn": null,
+            "account": "",
+            "portal_url": "",
+            "noc_contact": "",
+            "admin_contact": "",
+            "comments": "",
+            "custom_fields": {}
+        },
+        {
+            "id": 2,
+            "name": "TEST2",
+            "slug": "test2",
             "asn": null,
             "account": "",
             "portal_url": "",

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -26,7 +26,7 @@ class Generic(object):
         ret = pynetbox.core.response.Record
         app = 'circuits'
 
-        def test_get_iall(self):
+        def test_get_iterall(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -34,7 +34,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).iall()
+                ret = getattr(nb, self.name).iterall()
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)
@@ -69,7 +69,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_ifilter(self):
+        def test_iterfilter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -77,7 +77,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).ifilter(name='test')
+                ret = getattr(nb, self.name).iterfilter(name='test')
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -1,6 +1,6 @@
 import unittest
 import six
-
+from typing import Generator
 from .util import Response
 import pynetbox
 
@@ -26,6 +26,28 @@ class Generic(object):
         ret = pynetbox.core.response.Record
         app = 'circuits'
 
+        def test_get_iall(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).iall()
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
         def test_get_all(self):
             with patch(
                 'pynetbox.core.query.requests.get',
@@ -40,6 +62,28 @@ class Generic(object):
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     'http://localhost:8000/api/{}/{}/'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
+        def test_ifilter(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).ifilter(name='test')
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/?name=test'.format(
                         self.app,
                         self.name.replace('_', '-')
                     ),

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -54,7 +54,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_get_iall(self):
+        def test_get_iterall(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -62,7 +62,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).iall()
+                ret = getattr(nb, self.name).iterall()
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)
@@ -97,7 +97,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_ifilter(self):
+        def test_iterfilter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -105,7 +105,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).ifilter(name='test')
+                ret = getattr(nb, self.name).iterfilter(name='test')
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -9,6 +9,7 @@ if six.PY3:
 else:
     from mock import patch
 
+from typing import Generator
 
 api = pynetbox.api(
     "http://localhost:8000",
@@ -53,6 +54,28 @@ class Generic(object):
                     verify=True
                 )
 
+        def test_get_iall(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).iall()
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
         def test_filter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
@@ -65,6 +88,28 @@ class Generic(object):
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/?name=test'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
+        def test_ifilter(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).ifilter(name='test')
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
                 mock.assert_called_with(
                     'http://localhost:8000/api/{}/{}/?name=test'.format(
                         self.app,

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -57,7 +57,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_get_iall(self):
+        def test_get_iterall(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -65,7 +65,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).iall()
+                ret = getattr(nb, self.name).iterall()
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)
@@ -100,7 +100,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_ifilter(self):
+        def test_iterfilter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -108,7 +108,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).ifilter(name='test')
+                ret = getattr(nb, self.name).iterfilter(name='test')
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)

--- a/tests/test_ipam.py
+++ b/tests/test_ipam.py
@@ -11,6 +11,7 @@ if six.PY3:
 else:
     from mock import patch
 
+from typing import Generator
 
 api = pynetbox.api(
     "http://localhost:8000",
@@ -56,6 +57,28 @@ class Generic(object):
                     verify=True
                 )
 
+        def test_get_iall(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).iall()
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
         def test_filter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
@@ -76,6 +99,29 @@ class Generic(object):
                     headers=HEADERS,
                     verify=True
                 )
+
+        def test_ifilter(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).ifilter(name='test')
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/?name=test'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
 
         def test_get(self):
             with patch(

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -9,6 +9,7 @@ if six.PY3:
 else:
     from mock import patch
 
+from typing import Generator
 
 api = pynetbox.api(
     "http://localhost:8000",
@@ -48,6 +49,28 @@ class Generic(object):
                     verify=True
                 )
 
+        def test_get_iall(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).iall()
+                self.assertTrue(ret)
+                rec1 = next(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
         def test_filter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
@@ -60,6 +83,28 @@ class Generic(object):
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/?name=test'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
+        def test_ifilter(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).ifilter(name='test')
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
                 mock.assert_called_with(
                     'http://localhost:8000/api/{}/{}/?name=test'.format(
                         self.app,

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -49,7 +49,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_get_iall(self):
+        def test_get_iterall(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -57,7 +57,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).iall()
+                ret = getattr(nb, self.name).iterall()
                 self.assertTrue(ret)
                 rec1 = next(ret)
                 self.assertTrue(isinstance(ret, Generator))
@@ -92,7 +92,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_ifilter(self):
+        def test_iterfilter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -100,7 +100,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).ifilter(name='test')
+                ret = getattr(nb, self.name).iterfilter(name='test')
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -28,7 +28,7 @@ class Generic(object):
         ret = pynetbox.core.response.Record
         app = 'virtualization'
 
-        def test_get_iall(self):
+        def test_get_iterall(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -36,7 +36,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).iall()
+                ret = getattr(nb, self.name).iterall()
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)
@@ -92,7 +92,7 @@ class Generic(object):
                     verify=True
                 )
 
-        def test_ifilter(self):
+        def test_iterfilter(self):
             with patch(
                 'pynetbox.core.query.requests.get',
                 return_value=Response(fixture='{}/{}.json'.format(
@@ -100,7 +100,7 @@ class Generic(object):
                     self.name
                 ))
             ) as mock:
-                ret = getattr(nb, self.name).ifilter(name='test')
+                ret = getattr(nb, self.name).iterfilter(name='test')
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, Generator))
                 rec1 = next(ret)

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -9,6 +9,7 @@ if six.PY3:
 else:
     from mock import patch
 
+from typing import Generator
 
 api = pynetbox.api(
     "http://localhost:8000",
@@ -26,6 +27,28 @@ class Generic(object):
         name = ''
         ret = pynetbox.core.response.Record
         app = 'virtualization'
+
+        def test_get_iall(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).iall()
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
 
         def test_get_all(self):
             with patch(
@@ -60,6 +83,28 @@ class Generic(object):
                 self.assertTrue(ret)
                 self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
+                mock.assert_called_with(
+                    'http://localhost:8000/api/{}/{}/?name=test'.format(
+                        self.app,
+                        self.name.replace('_', '-')
+                    ),
+                    headers=HEADERS,
+                    verify=True
+                )
+
+        def test_ifilter(self):
+            with patch(
+                'pynetbox.core.query.requests.get',
+                return_value=Response(fixture='{}/{}.json'.format(
+                    self.app,
+                    self.name
+                ))
+            ) as mock:
+                ret = getattr(nb, self.name).ifilter(name='test')
+                self.assertTrue(ret)
+                self.assertTrue(isinstance(ret, Generator))
+                rec1 = next(ret)
+                self.assertTrue(isinstance(rec1, self.ret))
                 mock.assert_called_with(
                     'http://localhost:8000/api/{}/{}/?name=test'.format(
                         self.app,


### PR DESCRIPTION
endpoint's `all()` and `filter()` return a list. It makes take minutes to get all records and especially when there are a lot of objects, it is useful to start processing the data as it arrives 
This also partially implements #270 - not entirely as it does not paginate but returns the objects as it gets them #