### PR TITLE
Function getnext() to fetch one by one

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -100,6 +100,23 @@ class Endpoint(object):
 
         return response_loader(req.get(), self.return_obj, self)
 
+    def getnext(self, *args):
+
+        try:
+            offset = args[0]
+        except IndexError:
+            offset = 0
+
+        req = Request(
+            offset=offset,
+            base=self.url,
+            token=self.token,
+            session_key=self.session_key,
+            http_session=self.api.http_session,
+        )
+
+        return response_loader(req.get(), self.return_obj, self)
+
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.
 

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -146,6 +146,7 @@ class Request(object):
         private_key=None,
         session_key=None,
         threading=False,
+        offset=None,
     ):
         """
         Instantiates a new Request object
@@ -169,6 +170,7 @@ class Request(object):
         self.http_session = http_session
         self.url = self.base if not key else "{}{}/".format(self.base, key)
         self.threading = threading
+        self.offset = offset
 
     def get_openapi(self):
         """ Gets the OpenAPI Spec """
@@ -323,6 +325,13 @@ class Request(object):
             else:
                 return req
 
+        def req_next():
+            req = self._make_call(add_params={
+                            "limit": 1,
+                            "offset": self.offset
+                        })["results"]
+            return req
+
         def req_all_threaded(add_params):
             if add_params is None:
                 # Limit must be 0 to discover the max page size
@@ -346,6 +355,8 @@ class Request(object):
             else:
                 return req
 
+        if self.offset is not None:
+            return req_next()
         if self.threading:
             return req_all_threaded(add_params)
 


### PR DESCRIPTION
Function getnext() returns 1 item to fetch one by one.

Returns the first or selected N-th element. Return None if N more them items.
For example:
````
i=0
device=nb.dcim.devices.getnext(i)
while device:
 print(device)
 device=nb.dcim.devices.getnext(i)
 i=i+1
````