### PR TITLE
Fixed req_all to actually return all pages of paginated results

### DIFF
--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -303,21 +303,8 @@ class Request(object):
             req = self._make_call(add_params=add_params)
             if isinstance(req, dict) and req.get("results") is not None:
                 ret = req["results"]
-                first_run = True
                 while req["next"]:
-                    # Not worrying about making sure add_params kwargs is
-                    # passed in here because results from detail routes aren't
-                    # paginated, thus far.
-                    if first_run:
-                        req = self._make_call(
-                            add_params={
-                                "limit": req["count"],
-                                "offset": len(req["results"]),
-                            }
-                        )
-                    else:
-                        req = self._make_call(url_override=req["next"])
-                    first_run = False
+                    req = self._make_call(url_override=req["next"])
                     ret.extend(req["results"])
                 return ret
             else:

--- a/tests/test_dcim.py
+++ b/tests/test_dcim.py
@@ -319,10 +319,10 @@ class InterfaceTestCase(Generic.Tests):
         self.assertTrue(isinstance(ret[0], self.ret))
         self.assertEqual(len(ret), 71)
         mock.assert_called_with(
-            "http://localhost:8000/api/dcim/interfaces/",
-            params={"limit": 221, "offset": 50},
+            "http://localhost:8000/api/dcim/interfaces/?limit=50&offset=50",
             json=None,
             headers=HEADERS,
+            params={},
         )
 
 


### PR DESCRIPTION
Since the first "next" request will always be on first_run, the previous code was preventing using a url_override and only returning the first page of results under all circumstances.

First code contribution here, my apologies if I should have gone through different channels first. I'm happy to redirect if required. I think this is just a fix to a small oversight, otherwise I'm not understanding the desired behavior here.