### PR TITLE
Always send self.id with save() and delete()

### DIFF
--- a/.github/workflows/py3pr.yml
+++ b/.github/workflows/py3pr.yml
@@ -19,10 +19,10 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install pynetbox and testing packages.
-        run: pip install . black pytest
+        run: pip install . black==19.10b0 pytest
 
       - name: Run Linter
-        run: black --check .
+        run: black --diff pynetbox tests
           
       - name: Run Tests
         run: pytest

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -382,7 +382,7 @@ class Record(object):
             if diff:
                 serialized = self.serialize()
                 req = Request(
-                    key=self.id if not self.url else None,
+                    key=self.id,
                     base=self.endpoint.url,
                     token=self.api.token,
                     session_key=self.api.session_key,
@@ -430,7 +430,7 @@ class Record(object):
         >>>
         """
         req = Request(
-            key=self.id if not self.url else None,
+            key=self.id,
             base=self.endpoint.url,
             token=self.api.token,
             session_key=self.api.session_key,

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -214,7 +214,7 @@ class RecordTestCase(unittest.TestCase):
                 "child": {
                     "id": 321,
                     "name": "test123",
-                    "url": "http://localhost:8080/api/test-app/test-endpoint/",
+                    "url": "http://localhost:8080/api/test-app/test-endpoint/321/",
                 },
             },
             app,
@@ -224,7 +224,7 @@ class RecordTestCase(unittest.TestCase):
         test.child.save()
         self.assertEqual(
             app.http_session.patch.call_args[0][0],
-            "http://localhost:8080/api/test-app/test-endpoint/",
+            "http://localhost:8080/api/test-app/test-endpoint/321/",
         )
 
     def test_endpoint_from_url(self):


### PR DESCRIPTION
Previous implementation's tests were broken and didn't catch the
incorrect behavior for saving nested objects. This should fix issues
with incorrect URLs being used for nested PATCH operations.

Fixes #267
Maybe #285 too?