### PR TITLE
Exclude tests directory from pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     include_package_data=True,
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=["requests>=2.20.0,<3.0", "six==1.*",],
     zip_safe=False,
     keywords=["netbox"],


### PR DESCRIPTION
Before the change, after installing `pynetbox`:

```
$ ls ../pynetboxvenv/lib64/python3.7/site-packages/
certifi                      pkg_resources                  six-1.15.0.dist-info
certifi-2020.6.20.dist-info  pkg_resources-0.0.0.dist-info  six.py
chardet                      __pycache__                    tests
chardet-3.0.4.dist-info      pynetbox                       urllib3
easy_install.py              pynetbox-5.1.0.dist-info       urllib3-1.25.10.dist-info
idna                         requests                       wheel
idna-2.10.dist-info          requests-2.24.0.dist-info      wheel-0.35.1.dist-info
pip                          setuptools
pip-20.2.3.dist-info         setuptools-40.8.0.dist-info

$ ls ../pynetboxvenv/lib64/python3.7/site-packages/tests/
fixtures     test_api.py       test_dcim.py   test_tenancy.py         util.py
__init__.py  test_app.py       test_ipam.py   test_virtualization.py
__pycache__  test_circuits.py  test_query.py  unit
$
```
= `pynetbox` tests have been installed in site-packages directory. They are not needed for using `pynetbox` though.

After the change, after installing `pynetbox` in a new venv:

```
$ ls ../pynetboxvenv/lib64/python3.7/site-packages/
certifi                        pynetbox
certifi-2020.6.20.dist-info    pynetbox-5.1.1.dev0+g4c3b0f8.d20201016.dist-info
chardet                        requests
chardet-3.0.4.dist-info        requests-2.24.0.dist-info
easy_install.py                setuptools
idna                           setuptools-40.8.0.dist-info
idna-2.10.dist-info            six-1.15.0.dist-info
pip                            six.py
pip-20.2.3.dist-info           urllib3
pkg_resources                  urllib3-1.25.10.dist-info
pkg_resources-0.0.0.dist-info  wheel
__pycache__                    wheel-0.35.1.dist-info
$
```
= no `pynetbox` tests in the site-packages directory.