### PR TITLE
Do not create new endpoint if plugin returns URL.

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -171,7 +171,7 @@ class Record(object):
         self.default_ret = Record
         self.endpoint = (
             self._endpoint_from_url(values["url"])
-            if values and "url" in values
+            if values and "url" in values and "/api/plugins/" not in values["url"]
             else endpoint
         )
         if values:


### PR DESCRIPTION
Fixes #302 

Tests passed, but looking through the test cases they just test getting installed plugins, not using the plugins API. I do not have time to write new tests to cover this whole case, sorry.