### PR TITLE
fix: tag management with netbox >= 2.9

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -101,6 +101,7 @@ class Api(object):
         self.extras = App(self, "extras")
         self.virtualization = App(self, "virtualization")
         self.plugins = PluginsApp(self)
+        self.api_version = None
 
     @property
     def version(self):

--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -98,7 +98,10 @@ class Endpoint(object):
             threading=self.api.threading,
         )
 
-        return response_loader(req.get(), self.return_obj, self)
+        get_req = req.get()
+        self.api.api_version = req.api_version
+
+        return response_loader(get_req, self.return_obj, self)
 
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.
@@ -158,7 +161,10 @@ class Endpoint(object):
         except RequestError:
             return None
 
-        return response_loader(req.get(), self.return_obj, self)
+        get_req = req.get()
+        self.api.api_version = req.api_version
+
+        return response_loader(get_req, self.return_obj, self)
 
     def filter(self, *args, **kwargs):
         r"""Queries the 'ListView' of a given endpoint.
@@ -222,7 +228,10 @@ class Endpoint(object):
             threading=self.api.threading,
         )
 
-        return response_loader(req.get(), self.return_obj, self)
+        get_req = req.get()
+        self.api.api_version = req.api_version
+
+        return response_loader(get_req, self.return_obj, self)
 
     def create(self, *args, **kwargs):
         r"""Creates an object on an endpoint.
@@ -280,9 +289,13 @@ class Endpoint(object):
             token=self.token,
             session_key=self.session_key,
             http_session=self.api.http_session,
-        ).post(args[0] if args else kwargs)
+        )
 
-        return response_loader(req, self.return_obj, self)
+        resp = req.post(args[0] if args else kwargs)
+        
+        self.api.api_version = req.api_version
+
+        return response_loader(resp, self.return_obj, self)
 
     def choices(self):
         """ Returns all choices from the endpoint.
@@ -321,7 +334,10 @@ class Endpoint(object):
             token=self.api.token,
             private_key=self.api.private_key,
             http_session=self.api.http_session,
-        ).options()
+        )
+        req.options()
+        self.api.api_version = req.api_version
+        
         try:
             post_data = req["actions"]["POST"]
         except KeyError:
@@ -382,8 +398,9 @@ class Endpoint(object):
             session_key=self.session_key,
             http_session=self.api.http_session,
         )
-
-        return ret.get_count()
+        resp = ret.get_count()
+        self.api.api_version = ret.api_version
+        return resp
 
 
 class DetailEndpoint(object):
@@ -417,10 +434,13 @@ class DetailEndpoint(object):
         :returns: A dictionary or list of dictionaries retrieved from
             NetBox.
         """
-        req = Request(**self.request_kwargs).get(add_params=kwargs)
+        req = Request(**self.request_kwargs)
+        resp = req.get(add_params=kwargs)
+
+        self.api.api_version = req.api_version
 
         if self.custom_return:
-            return response_loader(req, self.custom_return, self.parent_obj.endpoint)
+            return response_loader(resp, self.custom_return, self.parent_obj.endpoint)
         return req
 
     def create(self, data=None):
@@ -437,9 +457,12 @@ class DetailEndpoint(object):
             NetBox.
         """
         data = data or {}
-        req = Request(**self.request_kwargs).post(data)
+        req = Request(**self.request_kwargs)
+        resp = req.post(data)
+        self.api.api_version = req.api_version
+
         if self.custom_return:
-            return response_loader(req, self.custom_return, self.parent_obj.endpoint)
+            return response_loader(resp, self.custom_return, self.parent_obj.endpoint)
         return req
 
 

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -169,6 +169,7 @@ class Request(object):
         self.http_session = http_session
         self.url = self.base if not key else "{}{}/".format(self.base, key)
         self.threading = threading
+        self.api_version = None
 
     def get_openapi(self):
         """ Gets the OpenAPI Spec """
@@ -257,6 +258,8 @@ class Request(object):
         req = getattr(self.http_session, verb)(
             url_override or self.url, headers=headers, params=params, json=data
         )
+        
+        self.api_version = req.headers.get("API-Version", "")
 
         if req.status_code == 204 and verb == "post":
             raise AllocationError(req)

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -301,6 +301,7 @@ class Record(object):
                 http_session=self.api.http_session,
             )
             self._parse_values(req.get())
+            self.api.api_version = req.api_version
             self.has_details = True
             return True
         return False
@@ -329,7 +330,7 @@ class Record(object):
             init_vals = dict(self._init_cache)
 
         if self.api:
-            api_version = float(self.api.version)
+            api_version = float(self.api.api_version)
         else:
             api_version = 1
 
@@ -408,6 +409,7 @@ class Record(object):
                     http_session=self.api.http_session,
                 )
                 if req.patch({i: serialized[i] for i in diff}):
+                    self.api.api_version = req.api_version
                     return True
 
         return False
@@ -455,4 +457,6 @@ class Record(object):
             session_key=self.api.session_key,
             http_session=self.api.http_session,
         )
-        return True if req.delete() else False
+        resp = req.delete()
+        self.api.api_version = req.api_version
+        return True if resp else False

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -61,7 +61,7 @@ class RecordTestCase(unittest.TestCase):
                 },
             ],
         }
-        test_obj = Record(test_values, Mock(base_url="test"), None)
+        test_obj = Record(test_values, Mock(base_url="test", version="2.8"), None)
         test = test_obj.serialize()
         self.assertEqual(test["tagged_vlans"], [1, 2])
 
@@ -109,7 +109,7 @@ class RecordTestCase(unittest.TestCase):
                 }
             ],
         }
-        test_obj = Record(test_values, Mock(base_url="test"), None)
+        test_obj = Record(test_values, Mock(base_url="test", version="2.8"), None)
         test_obj.tagged_vlans.append(1)
         test = test_obj._diff()
         self.assertFalse(test)
@@ -205,6 +205,7 @@ class RecordTestCase(unittest.TestCase):
         app = Mock()
         app.token = "abc123"
         app.base_url = "http://localhost:8080/api"
+        app.version = "2.8"
         endpoint = Mock()
         endpoint.name = "test-endpoint"
         test = Record(

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,8 +2,9 @@ import json
 
 
 class Response(object):
-    def __init__(self, fixture=None, status_code=200, ok=True, content=None):
+    def __init__(self, fixture=None, status_code=200, ok=True, content=None, api_version=2.8):
         self.status_code = status_code
+        self.headers = { "API-Version": api_version}
         self.content = json.dumps(content) if content else self.load_fixture(fixture)
         self.ok = ok
 


### PR DESCRIPTION
Hello,

This PR is made with the purpose of keeping backward compatibility with previous versions. There's in my opinion another way arround I though about: we can make tags membership of `LIST_AS_SET` conditional to the API version and keep it the way it was.

This would force end users to first create or retrieve tags objects in or from Netbox API and use the records in the append() function. In this case  #291 would just need a version check conditional if i'm correct. But it wouldn't work when user provides a dictionnary.