### PR TITLE
Fixes #304: Change Record._endpoint_from_url() to count URL fields from the end

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -280,7 +280,11 @@ class Record(object):
             setattr(self, k, v)
 
     def _endpoint_from_url(self, url):
-        app, name = urlsplit(url).path.split("/")[-4:-2]
+        # Remove the base URL from the beginning
+        url = url[len(self.api.base_url):]
+        if url.startswith("/"):
+            url = url[1:]
+        app, name = urlsplit(url).path.split("/")[:2]
         return getattr(pynetbox.core.app.App(self.api, app), name)
 
     def full_details(self):

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -280,7 +280,7 @@ class Record(object):
             setattr(self, k, v)
 
     def _endpoint_from_url(self, url):
-        app, name = urlsplit(url).path.split("/")[2:4]
+        app, name = urlsplit(url).path.split("/")[-4:-2]
         return getattr(pynetbox.core.app.App(self.api, app), name)
 
     def full_details(self):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -227,6 +227,32 @@ class RecordTestCase(unittest.TestCase):
             "http://localhost:8080/api/test-app/test-endpoint/321/",
         )
 
+    def test_nested_write_with_directory_in_base_url(self):
+        app = Mock()
+        app.token = "abc123"
+        app.base_url = "http://localhost:8080/testing/api"
+        endpoint = Mock()
+        endpoint.name = "test-endpoint"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "child": {
+                    "id": 321,
+                    "name": "test123",
+                    "url": "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
+                },
+            },
+            app,
+            endpoint,
+        )
+        test.child.name = "test321"
+        test.child.save()
+        self.assertEqual(
+            app.http_session.patch.call_args[0][0],
+            "http://localhost:8080/testing/api/test-app/test-endpoint/321/",
+        )
+
     def test_endpoint_from_url(self):
         test = Record(
             {

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -254,13 +254,30 @@ class RecordTestCase(unittest.TestCase):
         )
 
     def test_endpoint_from_url(self):
+        api = Mock()
+        api.base_url = "http://localhost:8080/api"
         test = Record(
             {
                 "id": 123,
                 "name": "test",
                 "url": "http://localhost:8080/api/test-app/test-endpoint/1/",
             },
-            Mock(),
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertEqual(ret.name, "test-endpoint")
+
+    def test_endpoint_from_url_with_directory_in_base_url(self):
+        api = Mock()
+        api.base_url = "http://localhost:8080/testing/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost:8080/testing/api/test-app/test-endpoint/1/",
+            },
+            api,
             None,
         )
         ret = test._endpoint_from_url(test.url)


### PR DESCRIPTION
This is to support NetBox API base URLs with one or more directories. In those cases the previous code picked incorrect parts from the URL.

Fixes #304.