### PR TITLE
Change Record._endpoint_from_url() to handle stripped http/https default ports

### DIFF
--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -283,6 +283,22 @@ class RecordTestCase(unittest.TestCase):
         ret = test._endpoint_from_url(test.url)
         self.assertEqual(ret.name, "test-endpoint")
 
+    def test_endpoint_from_url_with_stripped_port(self):
+        api = Mock()
+        api.base_url = "http://localhost:80/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "http://localhost/api/test-app/test-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertTrue(ret.url.endswith("/api/test-app/test-endpoint"))
+        self.assertEqual(ret.name, "test-endpoint")
+
     def test_serialize_tag_list_order(self):
         """Add tests to ensure we're preserving tag order
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -283,7 +283,7 @@ class RecordTestCase(unittest.TestCase):
         ret = test._endpoint_from_url(test.url)
         self.assertEqual(ret.name, "test-endpoint")
 
-    def test_endpoint_from_url_with_stripped_port(self):
+    def test_endpoint_from_url_with_stripped_http_port(self):
         api = Mock()
         api.base_url = "http://localhost:80/api"
         test = Record(
@@ -291,6 +291,22 @@ class RecordTestCase(unittest.TestCase):
                 "id": 123,
                 "name": "test",
                 "url": "http://localhost/api/test-app/test-endpoint/1/",
+            },
+            api,
+            None,
+        )
+        ret = test._endpoint_from_url(test.url)
+        self.assertTrue(ret.url.endswith("/api/test-app/test-endpoint"))
+        self.assertEqual(ret.name, "test-endpoint")
+
+    def test_endpoint_from_url_with_stripped_https_port(self):
+        api = Mock()
+        api.base_url = "https://localhost:443/api"
+        test = Record(
+            {
+                "id": 123,
+                "name": "test",
+                "url": "https://localhost/api/test-app/test-endpoint/1/",
             },
             api,
             None,


### PR DESCRIPTION
Fixes #309 (that was caused by the parsing change in #308)

NetBox removes the default http/https (80 or 443 respectively) port from the response object URL even though it is given for any reason in the `pynetbox.Api` instantiation. That makes `Record._endpoint_from_url()` generate incorrect `App` names (it removes too many characters from the given URL) in those cases.

This PR makes `Record._endpoint_from_url()` to remove the default ports so that the `App` name is correctly parsed. Parsing does not look very elegant but works 😐