### PR TITLE
Change Record.serialize() to handle tags in NetBox 2.9+ format

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -346,8 +346,8 @@ class Record(object):
                         v.id if isinstance(v, Record) else v for v in current_val
                     ]
                     if i in LIST_AS_SET and (
-                        all(map(lambda t: isinstance(t, str), current_val))
-                        or all(map(lambda t: isinstance(t, int), current_val))
+                        all([isinstance(v, str) for v in current_val])
+                        or all([isinstance(v, int) for v in current_val])
                     ):
                         current_val = list(OrderedDict.fromkeys(current_val))
                 ret[i] = current_val

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -345,7 +345,10 @@ class Record(object):
                     current_val = [
                         v.id if isinstance(v, Record) else v for v in current_val
                     ]
-                    if i in LIST_AS_SET:
+                    if i in LIST_AS_SET and (
+                        all(map(lambda t: isinstance(t, str), current_val))
+                        or all(map(lambda t: isinstance(t, int), current_val))
+                    ):
                         current_val = list(OrderedDict.fromkeys(current_val))
                 ret[i] = current_val
         return ret

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -71,10 +71,28 @@ class RecordTestCase(unittest.TestCase):
         test = test_obj.serialize()
         self.assertEqual(test["units"], [12])
 
-    def test_serialize_tag_set(self):
+    def test_serialize_string_tag_set(self):
         test_values = {"id": 123, "tags": ["foo", "bar", "foo"]}
         test = Record(test_values, None, None).serialize()
         self.assertEqual(len(test["tags"]), 2)
+
+    def test_serialize_dict_tag_set(self):
+        test_values = {"id": 123, "tags": [
+            {
+                "id": 1,
+                "name": "foo",
+            },
+            {
+                "id": 2,
+                "name": "bar",
+            },
+            {
+                "id": 3,
+                "name": "baz",
+            },
+        ]}
+        test = Record(test_values, None, None).serialize()
+        self.assertEqual(len(test["tags"]), 3)
 
     def test_diff(self):
         test_values = {


### PR DESCRIPTION
With this PR `Record.serialize()` only tries to deduplicate `tags` (or `tagged_vlans`) if all the list members are either strings or integers, so NetBox 2.9+ style dicts will not be causing errors with `OrderedDict.fromkeys()` anymore. So this fixes #289.

It has to be noted that deduplicating dict-style tags (when dict is input by the user) is not straightforward due to various input formats allowed (id, name, slug). (Or the user can supply just the tag id.) My take is that the `pynetbox` user should do the deduplication checks herself if needed. And AFAIK NetBox does the deduplication anyway. Maybe that would call an extra note in the release notes that `pynetbox` does not enforce user-supplied tag deduplication anymore with new-style tags.

PoC with NetBox 2.9.11:
```
>>> netbox.extras.tags.get(name="Test1").id
5
>>> netbox.extras.tags.get(name="Test2").id
6
>>> d = netbox.dcim.devices.get(name="Test")
>>> d.tags
[]
>>> # Add tag by id
>>> d.tags.append(5)
>>> d.save()
True
>>> d = netbox.dcim.devices.get(name="Test")
>>> d.tags
[Test1]
>>> # Add tag by name in a dict
>>> d.tags.append({"name":"Test2"})
>>> d.save()
True
>>> d = netbox.dcim.devices.get(name="Test")
>>> d.tags
[Test1, Test2]
>>> # Remove the last item from the list
>>> d.tags.pop()
Test2
>>> d.tags
[Test1]
>>> d.save()
True
>>> d = netbox.dcim.devices.get(name="Test")
>>> d.tags
[Test1]
>>>
```

**Note:** I didn't specifically test this with NetBox 2.8 or older, but it **should** work as the `tags` list then contains all strings, so the "`all-isinstance`" statement returns `True` and ensures original behaviour.