### PR TITLE
Add Api.status() to be used with NetBox 2.10.0+

### DIFF
--- a/pynetbox/core/api.py
+++ b/pynetbox/core/api.py
@@ -148,3 +148,36 @@ class Api(object):
         return Request(
             base=self.base_url, http_session=self.http_session,
         ).get_openapi()
+
+    def status(self):
+        """Gets the status information from NetBox.
+
+        Available in NetBox 2.10.0 or newer.
+
+        :Returns: Dictionary as returned by NetBox.
+        :Raises: :py:class:`.RequestError` if the request is not successful.
+        :Example:
+
+        >>> pprint.pprint(nb.status())
+        {'django-version': '3.1.3',
+         'installed-apps': {'cacheops': '5.0.1',
+                            'debug_toolbar': '3.1.1',
+                            'django_filters': '2.4.0',
+                            'django_prometheus': '2.1.0',
+                            'django_rq': '2.4.0',
+                            'django_tables2': '2.3.3',
+                            'drf_yasg': '1.20.0',
+                            'mptt': '0.11.0',
+                            'rest_framework': '3.12.2',
+                            'taggit': '1.3.0',
+                            'timezone_field': '4.0'},
+         'netbox-version': '2.10.2',
+         'plugins': {},
+         'python-version': '3.7.3',
+         'rq-workers-running': 1}
+        >>>
+        """
+        status = Request(
+            base=self.base_url, token=self.token, http_session=self.http_session,
+        ).get_status()
+        return status

--- a/pynetbox/core/query.py
+++ b/pynetbox/core/query.py
@@ -228,6 +228,23 @@ class Request(object):
         else:
             raise RequestError(req)
 
+    def get_status(self):
+        """ Gets the status from /api/status/ endpoint in NetBox.
+
+        :Returns: Dictionary as returned by NetBox.
+        :Raises: RequestError if request is not successful.
+        """
+        headers = {"Content-Type": "application/json;"}
+        if self.token:
+            headers["authorization"] = "Token {}".format(self.token)
+        req = self.http_session.get(
+            "{}status/".format(self.normalize_url(self.base)), headers=headers,
+        )
+        if req.ok:
+            return req.json()
+        else:
+            raise RequestError(req)
+
     def normalize_url(self, url):
         """ Builds a url for POST actions.
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,3 +70,20 @@ class ApiVersionTestCase(unittest.TestCase):
     def test_api_version_not_found(self, *_):
         api = pynetbox.api(host,)
         self.assertEqual(api.version, "")
+
+
+class ApiStatusTestCase(unittest.TestCase):
+    class ResponseWithStatus:
+        ok = True
+        def json(self):
+            return {
+                "netbox-version": "0.9.9",
+            }
+
+    @patch(
+        "pynetbox.core.query.requests.sessions.Session.get",
+        return_value=ResponseWithStatus(),
+    )
+    def test_api_status(self, *_):
+        api = pynetbox.api(host,)
+        self.assertEqual(api.status()["netbox-version"], "0.9.9")


### PR DESCRIPTION
`/api/status/` was added in NetBox 2.10.0 in https://github.com/netbox-community/netbox/issues/4918.