### PR TITLE
Change Record._endpoint_from_url() path parsing to ignore host:port

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -280,11 +280,13 @@ class Record(object):
             setattr(self, k, v)
 
     def _endpoint_from_url(self, url):
-        # Remove the base URL from the beginning
-        url = url[len(self.api.base_url) :]
-        if url.startswith("/"):
-            url = url[1:]
-        app, name = urlsplit(url).path.split("/")[:2]
+        url_path = urlsplit(url).path
+        base_url_path_parts = urlsplit(self.api.base_url).path.split("/")
+        if len(base_url_path_parts) > 2:
+            # There are some extra directories in the path, remove them from url
+            extra_path = "/".join(base_url_path_parts[:-1])
+            url_path = url_path[len(extra_path) :]
+        app, name = url_path.split("/")[2:4]
         return getattr(pynetbox.core.app.App(self.api, app), name)
 
     def full_details(self):


### PR DESCRIPTION
This PR changes the logic in `Record._endpoint_from_url()`: with this change it does not matter what's in the host:port part of the URL as we always check the path of `Api.base_url`, and if it contains some extra leading directories, those extra directories will be removed from `url` before parsing the `app` and `name`.

There are two sides in this:
1. This enables the path parsing to work even if the host:port is for some reason different in the NetBox-returned URLs and in the `pynetbox` user-supplied `Api.base_url`.
2. This also masks out some reverse proxy configuration errors like in #322 (but that was the original behaviour before #308 introduced in `pynetbox` 5.1.1).

