### PR TITLE
Skip integration tests when required executables are missing

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -89,6 +89,11 @@ def devicetype_library_repo_dirpath(git_toplevel):
     Returns:
         str: The path of the directory of the devicetype-library repo we will use.
     """
+    try:
+        subp.check_call(["which", "git"])
+    except subp.CalledProcessError:
+        pytest.skip(msg="git executable was not found on the host")
+
     repo_fpath = os.path.join(git_toplevel, ".devicetype-library")
     if os.path.isdir(repo_fpath):
         subp.check_call(
@@ -249,6 +254,11 @@ def docker_compose_file(pytestconfig, netbox_docker_repo_dirpaths):
     """
     clean_netbox_docker_tmpfiles()
     clean_docker_objects()
+
+    try:
+        subp.check_call(["which", "docker"])
+    except subp.CalledProcessError:
+        pytest.skip(msg="docker executable was not found on the host")
 
     compose_files = []
 


### PR DESCRIPTION
If the running host is missing some of the required executables,
then skip running the integration tests with a reason as to why.

This changes the experience when either docker or git is not present to be something like this (ran via `pytest -rsxvv`):
```
tests/test_api.py .....                                                                                           [  1%]
tests/test_app.py ....                                                                                            [  3%]
tests/test_circuits.py ..............                                                                             [  7%]
tests/test_dcim.py .............................................................................................. [ 39%]
.............................................................................                                     [ 65%]
tests/test_ipam.py ................................                                                               [ 76%]
tests/test_tenancy.py ......                                                                                      [ 78%]
tests/test_users.py ..........                                                                                    [ 82%]
tests/test_virtualization.py ...............                                                                      [ 87%]
tests/integration/test_dcim.py s                                                                                  [ 87%]
tests/integration/test_pytest_docker.py s                                                                         [ 88%]
tests/integration/test_dcim.py s                                                                                  [ 88%]
tests/integration/test_pytest_docker.py s                                                                         [ 88%]
tests/integration/test_dcim.py s                                                                                  [ 89%]
tests/integration/test_pytest_docker.py s                                                                         [ 89%]
tests/integration/test_dcim.py s                                                                                  [ 89%]
tests/integration/test_pytest_docker.py s                                                                         [ 90%]
tests/unit/test_endpoint.py ....                                                                                  [ 91%]
tests/unit/test_query.py ..                                                                                       [ 92%]
tests/unit/test_request.py .                                                                                      [ 92%]
tests/unit/test_response.py ......................                                                                [100%]

================================================ short test summary info ================================================
SKIPPED [8] tests/integration/conftest.py:261: docker executable was not found on the host
============================================ 286 passed, 8 skipped in 4.46s =============================================
```

Instead of the previous very verbose and unclear errors.