### PR TITLE
Implement RecordSets and add limit kwarg.

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -14,15 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from pynetbox.core.query import Request, RequestError
-from pynetbox.core.response import Record
+from pynetbox.core.response import Record, RecordSet
 
-RESERVED_KWARGS = ("id", "pk", "limit", "offset")
-
-
-def response_loader(req, return_obj, endpoint):
-    if isinstance(req, list):
-        return [return_obj(i, endpoint.api, endpoint) for i in req]
-    return return_obj(req, endpoint.api, endpoint)
+RESERVED_KWARGS = ("offset",)
 
 
 class Endpoint(object):
@@ -77,7 +71,7 @@ class Endpoint(object):
             ret = Record
         return ret
 
-    def all(self):
+    def all(self, limit=0):
         """Queries the 'ListView' of a given endpoint.
 
         Returns all objects from an endpoint.
@@ -96,9 +90,10 @@ class Endpoint(object):
             session_key=self.session_key,
             http_session=self.api.http_session,
             threading=self.api.threading,
+            limit=limit,
         )
 
-        return response_loader(req.get(), self.return_obj, self)
+        return RecordSet(self, req)
 
     def get(self, *args, **kwargs):
         r"""Queries the DetailsView of a given endpoint.
@@ -135,17 +130,7 @@ class Endpoint(object):
             key = None
 
         if not key:
-            filter_lookup = self.filter(**kwargs)
-            if filter_lookup:
-                if len(filter_lookup) > 1:
-                    raise ValueError(
-                        "get() returned more than one result. "
-                        "Check that the kwarg(s) passed are valid for this "
-                        "endpoint or use filter() or all() instead."
-                    )
-                else:
-                    return filter_lookup[0]
-            return None
+            return next(iter(self.filter(**kwargs)), None)
 
         req = Request(
             key=key,
@@ -154,16 +139,13 @@ class Endpoint(object):
             session_key=self.session_key,
             http_session=self.api.http_session,
         )
-
         try:
-            resp = req.get()
+            return next(iter(RecordSet(self, req)), None)
         except RequestError as e:
             if e.req.status_code == 404:
                 return None
             else:
                 raise e
-
-        return response_loader(resp, self.return_obj, self)
 
     def filter(self, *args, **kwargs):
         r"""Queries the 'ListView' of a given endpoint.
@@ -225,9 +207,10 @@ class Endpoint(object):
             session_key=self.session_key,
             http_session=self.api.http_session,
             threading=self.api.threading,
+            limit=kwargs.get("limit", 0),
         )
 
-        return response_loader(req.get(), self.return_obj, self)
+        return RecordSet(self, req)
 
     def create(self, *args, **kwargs):
         r"""Creates an object on an endpoint.
@@ -287,7 +270,7 @@ class Endpoint(object):
             http_session=self.api.http_session,
         ).post(args[0] if args else kwargs)
 
-        return response_loader(req, self.return_obj, self)
+        return self.return_obj(req, self.api, self)
 
     def choices(self):
         """ Returns all choices from the endpoint.
@@ -425,7 +408,10 @@ class DetailEndpoint(object):
         req = Request(**self.request_kwargs).get(add_params=kwargs)
 
         if self.custom_return:
-            return response_loader(req, self.custom_return, self.parent_obj.endpoint)
+            for i in req:
+                yield self.custom_return(
+                    i, self.parent_obj.endpoint.api, self.parent_obj.endpoint
+                )
         return req
 
     def create(self, data=None):
@@ -444,7 +430,9 @@ class DetailEndpoint(object):
         data = data or {}
         req = Request(**self.request_kwargs).post(data)
         if self.custom_return:
-            return response_loader(req, self.custom_return, self.parent_obj.endpoint)
+            return self.custom_return(
+                req, self.parent_obj.endpoint.api, self.parent_obj.endpoint
+            )
         return req
 
 

--- a/pynetbox/models/dcim.py
+++ b/pynetbox/models/dcim.py
@@ -24,13 +24,15 @@ from pynetbox.models.circuits import Circuits
 
 class TraceableRecord(Record):
     def trace(self):
-        req = Request(
-            key=str(self.id) + "/trace",
-            base=self.endpoint.url,
-            token=self.api.token,
-            session_key=self.api.session_key,
-            http_session=self.api.http_session,
-        )
+        req = list(
+            Request(
+                key=str(self.id) + "/trace",
+                base=self.endpoint.url,
+                token=self.api.token,
+                session_key=self.api.session_key,
+                http_session=self.api.http_session,
+            ).get()
+        )[0]
         uri_to_obj_class_map = {
             "dcim/cables": Cables,
             "dcim/front-ports": FrontPorts,
@@ -38,7 +40,7 @@ class TraceableRecord(Record):
             "dcim/rear-ports": RearPorts,
         }
         ret = []
-        for (termination_a_data, cable_data, termination_b_data) in req.get():
+        for (termination_a_data, cable_data, termination_b_data) in req:
             this_hop_ret = []
             for hop_item_data in (termination_a_data, cable_data, termination_b_data):
                 # if not fully terminated then some items will be None

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -27,9 +27,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).all()
+                ret = list(getattr(nb, self.name).all())
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(
@@ -45,9 +44,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).filter(name="test")
+                ret = list(getattr(nb, self.name).filter(name="test"))
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(

--- a/tests/test_tenancy.py
+++ b/tests/test_tenancy.py
@@ -28,9 +28,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).all()
+                ret = list(getattr(nb, self.name).all())
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(
@@ -46,9 +45,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).filter(name="test")
+                ret = list(getattr(nb, self.name).filter(name="test"))
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -28,9 +28,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).all()
+                ret = list(getattr(nb, self.name).all())
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(
@@ -46,9 +45,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).filter(name="test")
+                ret = list(getattr(nb, self.name).filter(name="test"))
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(

--- a/tests/test_virtualization.py
+++ b/tests/test_virtualization.py
@@ -28,9 +28,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).all()
+                ret = list(getattr(nb, self.name).all())
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(
@@ -46,9 +45,8 @@ class Generic(object):
                 "requests.sessions.Session.get",
                 return_value=Response(fixture="{}/{}.json".format(self.app, self.name)),
             ) as mock:
-                ret = getattr(nb, self.name).filter(name="test")
+                ret = list(getattr(nb, self.name).filter(name="test"))
                 self.assertTrue(ret)
-                self.assertTrue(isinstance(ret, list))
                 self.assertTrue(isinstance(ret[0], self.ret))
                 mock.assert_called_with(
                     "http://localhost:8000/api/{}/{}/".format(

--- a/tests/unit/test_endpoint.py
+++ b/tests/unit/test_endpoint.py
@@ -12,7 +12,9 @@ else:
 
 class EndPointTestCase(unittest.TestCase):
     def test_filter(self):
-        with patch("pynetbox.core.query.Request.get", return_value=Mock()) as mock:
+        with patch(
+            "pynetbox.core.query.Request._make_call", return_value=Mock()
+        ) as mock:
             api = Mock(base_url="http://localhost:8000/api")
             app = Mock(name="test")
             mock.return_value = [{"id": 123}, {"id": 321}]
@@ -34,7 +36,7 @@ class EndPointTestCase(unittest.TestCase):
         app = Mock(name="test")
         test_obj = Endpoint(api, app, "test")
         with self.assertRaises(ValueError) as _:
-            test_obj.filter(id=1)
+            test_obj.filter(offset=1)
 
     def test_choices(self):
         with patch("pynetbox.core.query.Request.options", return_value=Mock()) as mock:


### PR DESCRIPTION
Endpoint.all() and .filter() return RecordSet objects now. Also changed
is response from Request.get() is a generator now that's relayed through
the RecordSet object. We can pass .all() and filter() a limit kwarg now
that controls progress through paginated results (in non-threaded scenarios).

Fixes #341 & #270