### PR TITLE
Add a __next__ method to complete the iterator protocol

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -133,7 +133,7 @@ class Endpoint(object):
             key = None
 
         if not key:
-            return next(iter(self.filter(**kwargs)), None)
+            return next(self.filter(**kwargs), None)
 
         req = Request(
             key=key,
@@ -143,7 +143,7 @@ class Endpoint(object):
             http_session=self.api.http_session,
         )
         try:
-            return next(iter(RecordSet(self, req)), None)
+            return next(RecordSet(self, req), None)
         except RequestError as e:
             if e.req.status_code == 404:
                 return None

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -78,16 +78,16 @@ class RecordSet(object):
         self._response_cache = []
 
     def __iter__(self):
-        for i in self._response_cache:
-            yield self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
+        if self._response_cache:
+            yield self.endpoint.return_obj(
+                self._response_cache.pop(), self.endpoint.api, self.endpoint
+            )
         for i in self.response:
             yield self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
 
     def __next__(self):
-        for i in self._response_cache:
-            return self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
-        for i in self.response:
-            return self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
+        for i in self:
+            return i
 
     def __len__(self):
         try:

--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -83,6 +83,12 @@ class RecordSet(object):
         for i in self.response:
             yield self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
 
+    def __next__(self):
+        for i in self._response_cache:
+            return self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
+        for i in self.response:
+            return self.endpoint.return_obj(i, self.endpoint.api, self.endpoint)
+
     def __len__(self):
         try:
             return self.request.count


### PR DESCRIPTION
Implement the `__next__` method to complete the iterator protocol

Fix #354 