### PR TITLE
Fix len() calls for empty RecordSet

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -87,7 +87,10 @@ class RecordSet(object):
         try:
             return self.request.count
         except AttributeError:
-            self._response_cache.append(next(self.response))
+            try:
+                self._response_cache.append(next(self.response))
+            except StopIteration:
+                return 0
             return self.request.count
 
 


### PR DESCRIPTION
This PR tries to catch the case where StopIteration is returned immediately, for an empty RecordSet.

With this patch:

```
In [1]: import pynetbox, subprocess, os

In [2]: api = pynetbox.api('https://netbox.xy.zz', token=os.environ['NETBOX_TOKEN'])

In [3]: len(api.dcim.interfaces.filter(device='gpu-2c-mid-v3-b340dbe46d67be30cdeb.www.xy.zz'))
Out[3]: 12

In [4]: len(api.dcim.interfaces.filter(device='doesnotexist'))
Out[4]: 0
```

Without:

```
In [1]: import pynetbox, subprocess, os

In [2]: api = pynetbox.api('https://netbox.xy.zz', token=os.environ['NETBOX_TOKEN'])

In [3]: len(api.dcim.interfaces.filter(device='gpu-2c-mid-v3-b340dbe46d67be30cdeb.www.xy.zz'))
Out[3]: 12

In [4]: len(api.dcim.interfaces.filter(device='doesnotexist'))
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/.local/lib/python3.9/site-packages/pynetbox/core/response.py in __len__(self)
     87         try:
---> 88             return self.request.count
     89         except AttributeError:

AttributeError: 'Request' object has no attribute 'count'

During handling of the above exception, another exception occurred:

StopIteration                             Traceback (most recent call last)
<ipython-input-4-03292a1fccf7> in <module>
----> 1 len(api.dcim.interfaces.filter(device='doesnotexist'))

~/.local/lib/python3.9/site-packages/pynetbox/core/response.py in __len__(self)
     88             return self.request.count
     89         except AttributeError:
---> 90             self._response_cache.append(next(self.response))
     91             return self.request.count
     92 

StopIteration: 
```

Fix #355 