### PR TITLE
Deepcopy in _parse_values

### DIFF
--- a/pynetbox/core/response.py
+++ b/pynetbox/core/response.py
@@ -268,10 +268,7 @@ class Record(object):
 
     def _add_cache(self, item):
         key, value = item
-        if key == "local_context_data":
-            self._init_cache.append((key, copy.deepcopy(value)))
-        else:
-            self._init_cache.append((key, get_return(value)))
+        self._init_cache.append((key, get_return(value)))
 
     def _parse_values(self, values):
         """ Parses values init arg.
@@ -291,7 +288,7 @@ class Record(object):
                 if k in ["custom_fields", "local_context_data"] or hasattr(
                     lookup, "_json_field"
                 ):
-                    self._add_cache((k, v.copy()))
+                    self._add_cache((k, copy.deepcopy(v)))
                     setattr(self, k, v)
                     continue
                 if lookup:

--- a/tests/unit/test_extras.py
+++ b/tests/unit/test_extras.py
@@ -1,0 +1,40 @@
+import unittest
+
+import six
+
+from pynetbox.models.extras import ConfigContexts
+
+
+class ExtrasTestCase(unittest.TestCase):
+    def test_config_contexts(self):
+        test_values = {
+            "data": {"test_int": 123, "test_str": "testing", "test_list": [1, 2, 3],}
+        }
+        test = ConfigContexts(test_values, None, None)
+        self.assertTrue(test)
+
+    def test_config_contexts_diff_str(self):
+        test_values = {
+            "data": {
+                "test_int": 123,
+                "test_str": "testing",
+                "test_list": [1, 2, 3],
+                "test_dict": {"foo": "bar"},
+            }
+        }
+        test = ConfigContexts(test_values, None, None)
+        test.data["test_str"] = "bar"
+        self.assertEqual(test._diff(), {"data"})
+
+    def test_config_contexts_diff_dict(self):
+        test_values = {
+            "data": {
+                "test_int": 123,
+                "test_str": "testing",
+                "test_list": [1, 2, 3],
+                "test_dict": {"foo": "bar"},
+            }
+        }
+        test = ConfigContexts(test_values, None, None)
+        test.data["test_dict"].update({"bar": "foo"})
+        self.assertEqual(test._diff(), {"data"})


### PR DESCRIPTION
Go ahead and deepcopy if field is either of the built-in json fields
(custom_fields or local_context_data) or if field is a JsonField object
(ConfigContexts.data).
