### PR TITLE
Account for list returning from create

### DIFF
--- a/pynetbox/core/endpoint.py
+++ b/pynetbox/core/endpoint.py
@@ -308,6 +308,8 @@ class Endpoint(object):
             http_session=self.api.http_session,
         ).post(args[0] if args else kwargs)
 
+        if isinstance(req, list):
+            return [self.return_obj(i, self.api, self) for i in req]
         return self.return_obj(req, self.api, self)
 
     def choices(self):

--- a/tests/integration/test_dcim.py
+++ b/tests/integration/test_dcim.py
@@ -90,10 +90,12 @@ class TestSite(BaseTest):
 
     @pytest.fixture(scope="class")
     def add_sites(self, api):
-        sites = [
-            api.dcim.sites.create(name="test{}".format(i), slug="test{}".format(i))
-            for i in range(2, 20)
-        ]
+        sites = api.dcim.sites.create(
+            [
+                {"name": "test{}".format(i), "slug": "test{}".format(i)}
+                for i in range(2, 20)
+            ]
+        )
         yield
         for i in sites:
             i.delete()


### PR DESCRIPTION
Fixes #369 - When response_loader was removed the work it was doing to account for lists returning from queries was missed.